### PR TITLE
Fix delivery error

### DIFF
--- a/d4s2_api/tests_utils.py
+++ b/d4s2_api/tests_utils.py
@@ -1,4 +1,4 @@
-from mock import patch, Mock, MagicMock
+from mock import patch, Mock
 from django.test import TestCase
 from d4s2_api.utils import perform_delivery, DeliveryMessage
 from d4s2_api.models import Delivery, DukeDSProject, DukeDSUser

--- a/switchboard/dds_util.py
+++ b/switchboard/dds_util.py
@@ -104,7 +104,7 @@ class DeliveryDetails(object):
             raise RuntimeError('No email template found')
 
     def get_action_template_text(self, action_name):
-        email_template = EmailTemplate.by_action(self.delivery, action_name)
+        email_template = EmailTemplate.for_operation(self.delivery, action_name)
         if email_template:
             return email_template.subject, email_template.body
         else:

--- a/switchboard/tests_ddsutil.py
+++ b/switchboard/tests_ddsutil.py
@@ -136,8 +136,7 @@ class TestDeliveryDetails(TestCase):
 
     @mock.patch('switchboard.dds_util.EmailTemplate')
     def test_gets_share_template(self, MockEmailTemplate):
-        MockEmailTemplate.for_share = mock.Mock()
-        MockEmailTemplate.for_share.return_value = mock.MagicMock(subject='share subject', body='share body')
+        MockEmailTemplate.for_share = mock.Mock(return_value=mock.MagicMock(subject='share subject', body='share body'))
         delivery = mock.Mock()
         details = DeliveryDetails(delivery)
         subject, body = details.get_share_template_text()
@@ -147,8 +146,7 @@ class TestDeliveryDetails(TestCase):
 
     @mock.patch('switchboard.dds_util.EmailTemplate')
     def test_gets_action_template(self, MockEmailTemplate):
-        MockEmailTemplate.for_operation = mock.Mock()
-        MockEmailTemplate.for_operation.return_value = mock.MagicMock(subject='action subject', body='action body')
+        MockEmailTemplate.for_operation = mock.Mock(return_value=mock.MagicMock(subject='action subject', body='action body'))
         delivery = mock.Mock()
         details = DeliveryDetails(delivery)
         subject, body = details.get_action_template_text('accepted')

--- a/switchboard/tests_ddsutil.py
+++ b/switchboard/tests_ddsutil.py
@@ -130,3 +130,28 @@ class TestModelPopulator(TestCase):
         m.populate_project(p)
         self.assertTrue(p.populated())
         self.assertFalse(dds_util.get_remote_project.called)
+
+
+class TestDeliveryDetails(TestCase):
+
+    @mock.patch('switchboard.dds_util.EmailTemplate')
+    def test_gets_share_template(self, MockEmailTemplate):
+        MockEmailTemplate.for_share = mock.Mock()
+        MockEmailTemplate.for_share.return_value = mock.MagicMock(subject='share subject', body='share body')
+        delivery = mock.Mock()
+        details = DeliveryDetails(delivery)
+        subject, body = details.get_share_template_text()
+        self.assertTrue(MockEmailTemplate.for_share.called_with(delivery))
+        self.assertEqual(subject, 'share subject')
+        self.assertEqual(body, 'share body')
+
+    @mock.patch('switchboard.dds_util.EmailTemplate')
+    def test_gets_action_template(self, MockEmailTemplate):
+        MockEmailTemplate.for_operation = mock.Mock()
+        MockEmailTemplate.for_operation.return_value = mock.MagicMock(subject='action subject', body='action body')
+        delivery = mock.Mock()
+        details = DeliveryDetails(delivery)
+        subject, body = details.get_action_template_text('accepted')
+        self.assertEqual(subject, 'action subject')
+        self.assertEqual(body, 'action body')
+        self.assertTrue(MockEmailTemplate.for_operation.called_with(delivery, 'accepted'))


### PR DESCRIPTION
Fixes issue where deliveries can't be sent:


Traceback:

File "/usr/local/lib/python2.7/site-packages/django/core/handlers/base.py" in get_response
  149.                     response = self.process_exception_by_middleware(e, request)

File "/usr/local/lib/python2.7/site-packages/django/core/handlers/base.py" in get_response
  147.                     response = wrapped_callback(request, *callback_args, **callback_kwargs)

File "/usr/local/lib/python2.7/site-packages/django/views/decorators/csrf.py" in wrapped_view
  58.         return view_func(*args, **kwargs)

File "/usr/local/lib/python2.7/site-packages/rest_framework/viewsets.py" in view
  87.             return self.dispatch(request, *args, **kwargs)

File "/usr/local/lib/python2.7/site-packages/rest_framework/views.py" in dispatch
  466.             response = self.handle_exception(exc)

File "/usr/local/lib/python2.7/site-packages/rest_framework/views.py" in dispatch
  463.             response = handler(request, *args, **kwargs)

File "/usr/src/app/d4s2_api/views.py" in send
  105.         message = DeliveryMessage(delivery, accept_url)

File "/usr/src/app/d4s2_api/utils.py" in __init__
  72.         template_subject, template_body = delivery_details.get_action_template_text('delivery')

File "/usr/src/app/switchboard/dds_util.py" in get_action_template_text
  107.         email_template = EmailTemplate.by_action(self.delivery, action_name)

Exception Type: AttributeError at /api/v1/deliveries/1/send/
Exception Value: type object 'EmailTemplate' has no attribute 'by_action'
