### PR TITLE
Reworks production docker configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@ env3
 db.sqlite3
 settings.py
 d4s2.env
+certdata
+dbdata

--- a/docker-compose.apache.yml
+++ b/docker-compose.apache.yml
@@ -7,7 +7,7 @@ services:
       - "80:80"
       - "443:443"
     volumes:
-      - /etc/external/:/etc/external/
+      - './certdata:/etc/external/'
     # docker-compose doesn't allow specifying the entrypoint while preserving the
     # Dockerfile's command. Since the base docker-compose file specifies an entrypoint
     # we must provide the command here.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,7 @@ services:
     image: postgres
     env_file: d4s2.env
     volumes:
-      - /var/lib/postgresql/data:/var/lib/postgresql/data
+      - ./dbdata:/var/lib/postgresql/data
   web:
     build: .
     image: quay.io/dukegcb/d4s2

--- a/production/Dockerfile
+++ b/production/Dockerfile
@@ -3,9 +3,9 @@ MAINTAINER dan.leehr@duke.edu
 
 # apache2 / supervisor
 RUN apt-get update \
-  && apt-get install -y apache2 libapache2-mod-shib2 libapache2-mod-wsgi\
+  && apt-get install -y apache2 libapache2-mod-shib2 libapache2-mod-wsgi vim\
   && apt-get clean
-RUN pip install supervisor supervisor-stdout
+RUN pip install supervisor
 
 # Configure supervisor
 ADD supervisord.conf /etc/supervisord.conf
@@ -28,6 +28,7 @@ RUN service shibd stop
 
 # Additional requirements for production instance
 COPY requirements-production.txt /usr/src/app/
+ADD start-apache.sh /usr/src/app/
 RUN pip install --no-cache-dir -r requirements-production.txt
 
 # Replace settings with production-specific

--- a/production/d4s2.conf
+++ b/production/d4s2.conf
@@ -1,3 +1,7 @@
+# Redirect ALL apache error log to /dev/stderr
+# If we only do this in the VirtualHost, we don't catch wsgi stuff
+ErrorLog /dev/stderr
+
 # Always redirect to SSL
 ServerName d4s2.gcb.duke.edu
 <VirtualHost *:80>
@@ -43,9 +47,8 @@ WSGIPassAuthorization On
   SSLCertificateFile /etc/external/ssl/cacert.pem
   SSLCertificateKeyFile /etc/external/ssl/privkey.pem
   SSLCipherSuite HIGH:!aNULL:!MD5
-  # Redirect apache logs to docker stdout/stderr
   LogFormat "%h %l %u %t \"%r\" %>s %b \"%{Referer}i\" \"%{User-agent}i\"" combined
+  # Redirect logging to stdout.
   CustomLog /dev/stdout combined
-  ErrorLog /dev/stderr
 </VirtualHost>
 

--- a/production/start-apache.sh
+++ b/production/start-apache.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+#ensures database is migrated before each start of the production application
+/usr/local/bin/python manage.py migrate
+
+/usr/sbin/apachectl -DFOREGROUND

--- a/production/supervisord.conf
+++ b/production/supervisord.conf
@@ -3,23 +3,15 @@ nodaemon = true
 
 [program:shibd]
 command = /usr/sbin/shibd -fF -w 10
-stdout_events_enabled = true
-stderr_events_enabled = true
+redirect_stderr = true
+stdout_logfile = /dev/stdout
+stdout_logfile_maxbytes = 0
 
 [program:apache]
-command=apachectl -DFOREGROUND
-autostart=true
-autorestart=true
-startretries=1
-startsecs=1
-user=root
-killasgroup=true
-stopasgroup=true
-stdout_events_enabled = true
-stderr_events_enabled = true
+command = /usr/src/app/start-apache.sh
+killasgroup = true
+stopasgroup = true
+redirect_stderr = true
+stdout_logfile = /dev/stdout
+stdout_logfile_maxbytes = 0
 
-[eventlistener:stdout]
-command = supervisor_stdout
-buffer_size = 100
-events = PROCESS_LOG
-result_handler = supervisor_stdout:event_handler


### PR DESCRIPTION
- Redirects apache error logs (and VirtualHost access logs) to stdout for supervisor to send to docker
- Rewrites supervisord.conf, without supervisor-stdout program
- Adds start-apache.sh script that runs a migration before starting apache
- Includes vim in the Dockerfile
- Replaces docker-compose volume paths with mac-friendly paths
- moves production.yml -> docker-compose.apache.yml

Fixes #37