### PR TITLE
Removes apache2.pid before starting apache

### DIFF
--- a/production/start-apache.sh
+++ b/production/start-apache.sh
@@ -8,4 +8,7 @@ if [ -f /etc/external/fixtures.json ]; then
   /usr/local/bin/python manage.py loaddata /etc/external/fixtures.json
 fi
 
+# Apache gets grumpy about PID files pre-existing
+rm -f /var/run/apache2/apache2.pid
+
 /usr/sbin/apachectl -DFOREGROUND


### PR DESCRIPTION
When the container restarts after a host reboot, the pid file is not removed correctly, even though the pid is not running.
So it's safe to remove it here before starting apache

Fixes #66