### PR TITLE
Moves username/password field off primary login page to login-local

### DIFF
--- a/d4s2/urls.py
+++ b/d4s2/urls.py
@@ -14,6 +14,7 @@ urlpatterns = [
     url(r'^api-token-auth/', authtoken_views.obtain_auth_token),
     url(r'^accounts/login/$', auth_views.login, {'template_name': 'd4s2_auth/login.html' }, name='login'),
     url(r'^accounts/logout/$', auth_views.logout, {'template_name': 'd4s2_auth/logged_out.html' }, name='logout'),
+    url(r'^accounts/login-local/$', auth_views.login, {'template_name': 'd4s2_auth/login-local.html'}, name='login-local'),
     # Redirect / to /accounts/login
     url(r'^$', RedirectView.as_view(pattern_name='auth-home', permanent=False)),
 ]

--- a/d4s2_auth/templates/d4s2_auth/login-local.html
+++ b/d4s2_auth/templates/d4s2_auth/login-local.html
@@ -1,0 +1,34 @@
+{% extends "base.html" %}
+{% block title %}Login{% endblock %}
+{% block content %}
+<h4>Login - Local Admin</h4>
+{% if form.errors %}
+<p>Your username and password didn't match. Please try again.</p>
+{% endif %}
+
+{% if next %}
+    {% if user.is_authenticated %}
+    <p>Your account doesn't have access to this page. To proceed,
+    please login with an account that has access.</p>
+    {% else %}
+    <p>Please login to see this page.</p>
+    {% endif %}
+{% endif %}
+<p>This page is local administrator login only. To login with a Duke NetID, click <a href="{% url 'auth-authorize' %}?next={{ next }}">here</a>.</p>
+<form method="post" action="{% url 'login' %}">
+{% csrf_token %}
+<table>
+<tr>
+    <td>{{ form.username.label_tag }}</td>
+    <td>{{ form.username }}</td>
+</tr>
+<tr>
+    <td>{{ form.password.label_tag }}</td>
+    <td>{{ form.password }}</td>
+</tr>
+</table>
+
+<input type="submit" value="login" />
+<input type="hidden" name="next" value="{{ next }}" />
+</form>
+{% endblock %}

--- a/d4s2_auth/templates/d4s2_auth/login.html
+++ b/d4s2_auth/templates/d4s2_auth/login.html
@@ -11,25 +11,9 @@
     <p>Your account doesn't have access to this page. To proceed,
     please login with an account that has access.</p>
     {% else %}
-    <p>Please login to see this page.</p>
+    <p>This page requires authentication.</p>
     {% endif %}
 {% endif %}
-<p><a href="{% url 'auth-authorize' %}?next={{ next }}">Login with Duke OAuth</a></p>
-<p>Or, if you have a local account, log in here.</p>
-<form method="post" action="{% url 'login' %}">
-{% csrf_token %}
-<table>
-<tr>
-    <td>{{ form.username.label_tag }}</td>
-    <td>{{ form.username }}</td>
-</tr>
-<tr>
-    <td>{{ form.password.label_tag }}</td>
-    <td>{{ form.password }}</td>
-</tr>
-</table>
-
-<input type="submit" value="login" />
-<input type="hidden" name="next" value="{{ next }}" />
-</form>
+    <p><a href="{% url 'auth-authorize' %}?next={{ next }}">Click here</a> to login with your Duke NetID.</p>
+    <p><a class="login_local" href="{% url 'login-local' %}?next={{ next }}">Admin Login</a></p>
 {% endblock %}

--- a/static/main.css
+++ b/static/main.css
@@ -26,3 +26,9 @@
     color: red;
     font-weight: bold;
 }
+
+a.login_local {
+    font-size: small;
+    color: rgb(180,180,180);
+    text-decoration: none;
+}


### PR DESCRIPTION
- login-local only used for django accounts, so the form should not appear in the common use cases
- Adds link to local login, with gray link

Fixes #73