### PR TITLE
Fix confirmation recipient

### DIFF
--- a/d4s2_api/tests_utils.py
+++ b/d4s2_api/tests_utils.py
@@ -80,3 +80,25 @@ class UtilsTestCase(TestCase):
         self.assertIn('Action Body Template bob', message.email_text)
         self.assertIn('Action User Message msg', message.email_text)
 
+    @patch('d4s2_api.utils.DeliveryDetails')
+    def test_message_direction_share(self, MockDeliveryDetails):
+        setup_mock_delivery_details(MockDeliveryDetails)
+        message = ShareMessage(self.share)
+        self.assertEqual(message.email_receipients, ['bob@joe.com'], 'Share message should go to delivery recipient')
+        self.assertEqual(message.email_from, 'joe@joe.com', 'Share message should be from delivery sender')
+
+    @patch('d4s2_api.utils.DeliveryDetails')
+    def test_message_direction_delivery(self, MockDeliveryDetails):
+        setup_mock_delivery_details(MockDeliveryDetails)
+        message = DeliveryMessage(self.share,  'http://localhost/accept')
+        self.assertEqual(message.email_receipients, ['bob@joe.com'], 'Delivery message go to delivery recipient')
+        self.assertEqual(message.email_from, 'joe@joe.com', 'Delivery message should be from delivery sender')
+
+    @patch('d4s2_api.utils.DeliveryDetails')
+    def test_message_direction_processed(self, MockDeliveryDetails):
+        setup_mock_delivery_details(MockDeliveryDetails)
+        process_type = 'decline'
+        reason = 'sample reason'
+        message = ProcessedMessage(self.delivery, process_type, reason)
+        self.assertEqual(message.email_receipients, ['joe@joe.com'], 'Processed message should go to delivery sender')
+        self.assertEqual(message.email_from, 'bob@joe.com', 'Processed message should be from delivery recipient')

--- a/d4s2_api/tests_utils.py
+++ b/d4s2_api/tests_utils.py
@@ -117,9 +117,9 @@ class MessageDirectionTestCase(TestCase):
         self.assertEqual(ordered_addresses, (self.sender_email, self.receiver_email))
 
     def test_orders_forward(self):
-        ordered_addresses = MessageDirection.email_addresses(self.sender, self.receiver, MessageDirection.NotificationToRecipient)
+        ordered_addresses = MessageDirection.email_addresses(self.sender, self.receiver, MessageDirection.ToRecipient)
         self.assertEqual(ordered_addresses, (self.sender_email, self.receiver_email))
 
     def test_orders_reverse(self):
-        ordered_addresses = MessageDirection.email_addresses(self.sender, self.receiver, MessageDirection.ConfirmationToSender)
+        ordered_addresses = MessageDirection.email_addresses(self.sender, self.receiver, MessageDirection.ToSender)
         self.assertEqual(ordered_addresses, (self.receiver_email, self.sender_email))

--- a/d4s2_api/tests_utils.py
+++ b/d4s2_api/tests_utils.py
@@ -1,6 +1,6 @@
 from mock import patch, Mock
 from django.test import TestCase
-from d4s2_api.utils import accept_delivery, decline_delivery, ShareMessage, DeliveryMessage, ProcessedMessage
+from d4s2_api.utils import accept_delivery, decline_delivery, ShareMessage, DeliveryMessage, ProcessedMessage, MessageDirection
 from d4s2_api.models import Delivery, Share, DukeDSProject, DukeDSUser
 from ownership.test_views import setup_mock_delivery_details
 from django.contrib.auth.models import User, Group
@@ -102,3 +102,24 @@ class UtilsTestCase(TestCase):
         message = ProcessedMessage(self.delivery, process_type, reason)
         self.assertEqual(message.email_receipients, ['joe@joe.com'], 'Processed message should go to delivery sender')
         self.assertEqual(message.email_from, 'bob@joe.com', 'Processed message should be from delivery recipient')
+
+
+class MessageDirectionTestCase(TestCase):
+
+    def setUp(self):
+        self.sender_email = 'sender@email.com'
+        self.receiver_email = 'receiver@email.com'
+        self.sender = Mock(email=self.sender_email)
+        self.receiver = Mock(email=self.receiver_email)
+
+    def test_default_order(self):
+        ordered_addresses = MessageDirection.email_addresses(self.sender, self.receiver)
+        self.assertEqual(ordered_addresses, (self.sender_email, self.receiver_email))
+
+    def test_orders_forward(self):
+        ordered_addresses = MessageDirection.email_addresses(self.sender, self.receiver, MessageDirection.NotificationToRecipient)
+        self.assertEqual(ordered_addresses, (self.sender_email, self.receiver_email))
+
+    def test_orders_reverse(self):
+        ordered_addresses = MessageDirection.email_addresses(self.sender, self.receiver, MessageDirection.ConfirmationToSender)
+        self.assertEqual(ordered_addresses, (self.receiver_email, self.sender_email))

--- a/d4s2_api/utils.py
+++ b/d4s2_api/utils.py
@@ -3,12 +3,12 @@ from switchboard.dds_util import DeliveryDetails, DDSUtil
 
 
 class MessageDirection(object):
-    NotificationToRecipient = 0
-    ConfirmationToSender = 1
+    ToRecipient = 0
+    ToSender = 1
 
     @staticmethod
-    def email_addresses(sender, receiver, direction=NotificationToRecipient):
-        if direction == MessageDirection.NotificationToRecipient:
+    def email_addresses(sender, receiver, direction=ToRecipient):
+        if direction == MessageDirection.ToRecipient:
             return sender.email, receiver.email
         else:
             return receiver.email, sender.email
@@ -17,7 +17,7 @@ class MessageDirection(object):
 class Message(object):
 
     def __init__(self, deliverable, accept_url=None, reason=None, process_type=None,
-                 direction=MessageDirection.NotificationToRecipient):
+                 direction=MessageDirection.ToRecipient):
         """
         Fetches user and project details from DukeDS (DDSUtil) based on user and project IDs recorded
         in a models.Share or models.Delivery object. Then calls generate_message with email addresses, subject, and the details to
@@ -123,7 +123,7 @@ class ProcessedMessage(Message):
         """
         self.process_type = process_type
         super(ProcessedMessage, self).__init__(delivery, process_type=process_type, reason=reason,
-                                               direction=MessageDirection.ConfirmationToSender)
+                                               direction=MessageDirection.ToSender)
 
 
 def accept_delivery(delivery, user):


### PR DESCRIPTION
When sending ProcesedMessage (notification of acceptance or decline), the mailer was incorrectly sending the confirmation to the delivery recipient. Since this is a delivery confirmation message, it should go to the user who initiated the delivery.

Fixes #84 