### PR TITLE
Fix transferid not found

### DIFF
--- a/d4s2/settings_base.py
+++ b/d4s2/settings_base.py
@@ -131,7 +131,7 @@ EMAIL_BACKEND = 'django.core.mail.backends.console.EmailBackend'
 REST_FRAMEWORK = {
     'DEFAULT_FILTER_BACKENDS': ('rest_framework.filters.DjangoFilterBackend',),
     'DEFAULT_AUTHENTICATION_CLASSES': (
-        'gcb_web_auth.dukeds_auth.DukeDSTokenAuthentication', # Allows users to authenticate with a DukeDS token
+        'd4s2_api.dukeds_auth.D4S2DukeDSTokenAuthentication', # Allows users to authenticate with a DukeDS token
         'rest_framework.authentication.TokenAuthentication', # Allows users to authenticate with D4S2 rest_framework authtoken
         'rest_framework.authentication.SessionAuthentication',
     ),

--- a/d4s2/settings_base.py
+++ b/d4s2/settings_base.py
@@ -94,7 +94,7 @@ AUTH_PASSWORD_VALIDATORS = [
 AUTHENTICATION_BACKENDS = [
     'django.contrib.auth.backends.ModelBackend',
     'd4s2_api.dukeds_auth.D4S2DukeDSAuthBackend',
-    'gcb_web_auth.backends.oauth.OAuth2Backend',
+    'd4s2_api.dukeds_auth.D4S2OAuth2Backend',
 ]
 
 # Internationalization

--- a/d4s2/settings_base.py
+++ b/d4s2/settings_base.py
@@ -93,7 +93,7 @@ AUTH_PASSWORD_VALIDATORS = [
 
 AUTHENTICATION_BACKENDS = [
     'django.contrib.auth.backends.ModelBackend',
-    'gcb_web_auth.backends.dukeds.DukeDSAuthBackend',
+    'd4s2_api.dukeds_auth.D4S2DukeDSAuthBackend',
     'gcb_web_auth.backends.oauth.OAuth2Backend',
 ]
 
@@ -131,7 +131,7 @@ EMAIL_BACKEND = 'django.core.mail.backends.console.EmailBackend'
 REST_FRAMEWORK = {
     'DEFAULT_FILTER_BACKENDS': ('rest_framework.filters.DjangoFilterBackend',),
     'DEFAULT_AUTHENTICATION_CLASSES': (
-        'd4s2_api.dukeds_auth.D4S2DukeDSTokenAuthentication', # Allows users to authenticate with a DukeDS token
+        'gcb_web_auth.dukeds_auth.DukeDSTokenAuthentication', # Allows users to authenticate with a DukeDS token
         'rest_framework.authentication.TokenAuthentication', # Allows users to authenticate with D4S2 rest_framework authtoken
         'rest_framework.authentication.SessionAuthentication',
     ),

--- a/d4s2_api/dukeds_auth.py
+++ b/d4s2_api/dukeds_auth.py
@@ -19,6 +19,14 @@ class D4S2DukeDSAuthBackend(DukeDSAuthBackend):
             BaseBackend.update_model(dukeds_user, user_dict)
 
 
+class D4S2DukeDSTokenAuthentication(DukeDSTokenAuthentication):
+    """
+    Extends authorization to save users to DukeDSUser
+    """
+    def __init__(self):
+        self.backend = D4S2DukeDSAuthBackend()
+
+
 class D4S2OAuth2Backend(OAuth2Backend):
     """
     Slight customization to connect User objects to existing DukeDSUser objects (by email)

--- a/d4s2_api/dukeds_auth.py
+++ b/d4s2_api/dukeds_auth.py
@@ -9,7 +9,6 @@ class D4S2DukeDSAuthBackend(DukeDSAuthBackend):
     """
     DukeDSAuthBackend that updates a local user model with D4S2 details on creation
     """
-
     def handle_new_user(self, user, details):
         user_dict = DukeDSAuthBackend.harmonize_dukeds_user_details(details)
         dukeds_user, created = DukeDSUser.objects.get_or_create(dds_id=details.get('id'))
@@ -31,7 +30,7 @@ class D4S2OAuth2Backend(OAuth2Backend):
     """
     Slight customization to connect User objects to existing DukeDSUser objects (by email)
     """
-    def handle_new_oauth_user(self, user, details):
+    def handle_new_user(self, user, details):
         """
         When saving a new user from OAuth, check to see if an unlinked DukeDSUser object exists, and link it
         :param user: A django user, created after receiving OAuth details

--- a/d4s2_api/dukeds_auth.py
+++ b/d4s2_api/dukeds_auth.py
@@ -1,32 +1,39 @@
 from gcb_web_auth.dukeds_auth import DukeDSTokenAuthentication
 from gcb_web_auth.backends.dukeds import DukeDSAuthBackend
 from gcb_web_auth.backends.base import BaseBackend
+from gcb_web_auth.backends.oauth import OAuth2Backend
 from .models import DukeDSUser
-
-
-class D4S2DukeDSTokenAuthentication(DukeDSTokenAuthentication):
-    """
-    Extends authorization to save users to DukeDSUser
-    """
-    def __init__(self):
-        self.backend = DukeDSAuthBackend()
 
 
 class D4S2DukeDSAuthBackend(DukeDSAuthBackend):
     """
-    Backend for DukeDS Auth that save users to DukeDSUser
-    Conveniently, the keys used by DukeDS user objects are a superset of the django ones,
-    so we rely on the filtering in the base class
+    DukeDSAuthBackend that updates a local user model with D4S2 details on creation
     """
-    def __init__(self, save_tokens=True, save_dukeds_users=True):
-        super(D4S2DukeDSAuthBackend, self).__init__(save_tokens, save_dukeds_users)
-        self.save_tokens = save_tokens
-        self.save_dukeds_users = save_dukeds_users
-        self.failure_reason = None
 
-    def save_dukeds_user(self, user, raw_user_dict):
-        user_dict = DukeDSAuthBackend.harmonize_dukeds_user_details(raw_user_dict)
-        dukeds_user, created = DukeDSUser.objects.get_or_create(user=user,
-                                                                dds_id=raw_user_dict.get('id'))
+    def handle_new_user(self, user, details):
+        user_dict = DukeDSAuthBackend.harmonize_dukeds_user_details(details)
+        dukeds_user, created = DukeDSUser.objects.get_or_create(dds_id=details.get('id'))
+        dukeds_user.user = user
+        dukeds_user.save()
         if created:
             BaseBackend.update_model(dukeds_user, user_dict)
+
+
+class D4S2OAuth2Backend(OAuth2Backend):
+    """
+    Slight customization to connect User objects to existing DukeDSUser objects (by email)
+    """
+    def handle_new_oauth_user(self, user, details):
+        """
+        When saving a new user from OAuth, check to see if an unlinked DukeDSUser object exists, and link it
+        :param user: A django user, created after receiving OAuth details
+        :param details: A dictionary of OAuth user info
+        :return: None
+        """
+        try:
+            dukeds_user = DukeDSUser.objects.get(user=None, email=user.email)
+            dukeds_user.user = user
+            dukeds_user.save()
+        except DukeDSUser.DoesNotExist:
+            # Either user already linked or not found. Either way, don't do anything.
+            pass

--- a/d4s2_api/tests_utils.py
+++ b/d4s2_api/tests_utils.py
@@ -40,7 +40,7 @@ class UtilsTestCase(TestCase):
     @patch('d4s2_api.utils.DeliveryDetails')
     def test_delivery_message(self, MockDeliveryDetails):
         mock_details = setup_mock_delivery_details(MockDeliveryDetails)
-        message = DeliveryMessage(self.delivery, 'http://localhost/accept')
+        message = DeliveryMessage(self.delivery, self.user, 'http://localhost/accept')
         self.assertEqual(mock_details.get_project.call_count, 1)
         self.assertEqual(mock_details.get_from_user.call_count, 1)
         self.assertEqual(mock_details.get_to_user.call_count, 1)
@@ -54,7 +54,7 @@ class UtilsTestCase(TestCase):
     @patch('d4s2_api.utils.DeliveryDetails')
     def test_share_message(self, MockDeliveryDetails):
         mock_details = setup_mock_delivery_details(MockDeliveryDetails)
-        message = ShareMessage(self.share)
+        message = ShareMessage(self.share, self.user)
         self.assertEqual(mock_details.get_project.call_count, 1)
         self.assertEqual(mock_details.get_from_user.call_count, 1)
         self.assertEqual(mock_details.get_to_user.call_count, 1)
@@ -69,7 +69,7 @@ class UtilsTestCase(TestCase):
         mock_details = setup_mock_delivery_details(MockDeliveryDetails)
         process_type = 'decline'
         reason = 'sample reason'
-        message = ProcessedMessage(self.delivery, process_type, reason)
+        message = ProcessedMessage(self.delivery, self.user, process_type, reason)
         self.assertEqual(mock_details.get_project.call_count, 1)
         self.assertEqual(mock_details.get_from_user.call_count, 1)
         self.assertEqual(mock_details.get_to_user.call_count, 1)
@@ -83,14 +83,14 @@ class UtilsTestCase(TestCase):
     @patch('d4s2_api.utils.DeliveryDetails')
     def test_message_direction_share(self, MockDeliveryDetails):
         setup_mock_delivery_details(MockDeliveryDetails)
-        message = ShareMessage(self.share)
+        message = ShareMessage(self.share, self.user)
         self.assertEqual(message.email_receipients, ['bob@joe.com'], 'Share message should go to delivery recipient')
         self.assertEqual(message.email_from, 'joe@joe.com', 'Share message should be from delivery sender')
 
     @patch('d4s2_api.utils.DeliveryDetails')
     def test_message_direction_delivery(self, MockDeliveryDetails):
         setup_mock_delivery_details(MockDeliveryDetails)
-        message = DeliveryMessage(self.share,  'http://localhost/accept')
+        message = DeliveryMessage(self.share, self.user, 'http://localhost/accept')
         self.assertEqual(message.email_receipients, ['bob@joe.com'], 'Delivery message go to delivery recipient')
         self.assertEqual(message.email_from, 'joe@joe.com', 'Delivery message should be from delivery sender')
 
@@ -99,7 +99,7 @@ class UtilsTestCase(TestCase):
         setup_mock_delivery_details(MockDeliveryDetails)
         process_type = 'decline'
         reason = 'sample reason'
-        message = ProcessedMessage(self.delivery, process_type, reason)
+        message = ProcessedMessage(self.delivery, self.user, process_type, reason)
         self.assertEqual(message.email_receipients, ['joe@joe.com'], 'Processed message should go to delivery sender')
         self.assertEqual(message.email_from, 'bob@joe.com', 'Processed message should be from delivery recipient')
 

--- a/d4s2_api/tests_views.py
+++ b/d4s2_api/tests_views.py
@@ -133,7 +133,7 @@ class DeliveryViewTestCase(AuthenticatedResourceTestCase):
         # Make sure transfer_id is in the email message
         ownership_url = reverse('ownership-prompt')
         expected_absolute_url = APIRequestFactory().request().build_absolute_uri(ownership_url) + '?transfer_id=abcd'
-        mock_delivery_message.assert_called_with(h, expected_absolute_url)
+        mock_delivery_message.assert_called_with(h, self.user, expected_absolute_url)
         self.assertTrue(instance.send.called)
 
     @patch('d4s2_api.views.DeliveryMessage')

--- a/d4s2_api/views.py
+++ b/d4s2_api/views.py
@@ -104,7 +104,7 @@ class DeliveryViewSet(TransferViewSet):
             raise AlreadyNotifiedException(detail='Delivery already in progress')
         accept_path = reverse('ownership-prompt') + "?transfer_id=" + str(delivery.transfer_id)
         accept_url = request.build_absolute_uri(accept_path)
-        message = DeliveryMessage(delivery, accept_url)
+        message = DeliveryMessage(delivery, request.user, accept_url)
         message.send()
         delivery.mark_notified(message.email_text)
         return self.retrieve(request)
@@ -142,7 +142,7 @@ class ShareViewSet(TransferViewSet):
             force = False
         if share.is_notified() and not force:
             raise AlreadyNotifiedException()
-        message = ShareMessage(share)
+        message = ShareMessage(share, request.user)
         message.send()
         share.mark_notified(message.email_text)
         return self.retrieve(request)

--- a/switchboard/dds_util.py
+++ b/switchboard/dds_util.py
@@ -94,9 +94,9 @@ class ModelPopulator(object):
 
 
 class DeliveryDetails(object):
-    def __init__(self, delivery_or_share):
+    def __init__(self, delivery_or_share, user):
         self.delivery = delivery_or_share
-        self.ddsutil = DDSUtil(self.delivery.from_user.user)
+        self.ddsutil = DDSUtil(user)
         self.model_populator = ModelPopulator(self.ddsutil)
 
     def get_from_user(self):
@@ -136,12 +136,13 @@ class DeliveryDetails(object):
         return self.delivery
 
     @classmethod
-    def from_transfer_id(self, transfer_id):
+    def from_transfer_id(self, transfer_id, user):
         """
         Finds a local delivery by transfer id and ensures it's up-to-date with the server
         :param transfer_id: a DukeDS Project Transfer ID
+        :param user: a Django user with related DukeDS credentials
         :return: a d4s2_api.models.Delivery
         """
 
         delivery = Delivery.objects.get(transfer_id=transfer_id)
-        return DeliveryDetails(delivery)
+        return DeliveryDetails(delivery, user)

--- a/switchboard/tests_ddsutil.py
+++ b/switchboard/tests_ddsutil.py
@@ -164,7 +164,8 @@ class TestDeliveryDetails(TestCase):
     def test_gets_share_template(self, MockEmailTemplate):
         MockEmailTemplate.for_share = Mock(return_value=MagicMock(subject='share subject', body='share body'))
         delivery = Mock()
-        details = DeliveryDetails(delivery)
+        user = Mock()
+        details = DeliveryDetails(delivery, user)
         subject, body = details.get_share_template_text()
         self.assertTrue(MockEmailTemplate.for_share.called_with(delivery))
         self.assertEqual(subject, 'share subject')
@@ -174,7 +175,8 @@ class TestDeliveryDetails(TestCase):
     def test_gets_action_template(self, MockEmailTemplate):
         MockEmailTemplate.for_operation = Mock(return_value=MagicMock(subject='action subject', body='action body'))
         delivery = Mock()
-        details = DeliveryDetails(delivery)
+        user = Mock()
+        details = DeliveryDetails(delivery, user)
         subject, body = details.get_action_template_text('accepted')
         self.assertEqual(subject, 'action subject')
         self.assertEqual(body, 'action body')


### PR DESCRIPTION
Fixes the issue where recipients could not view a delivery by transfer ID because D4S2 attempted to authenticate with the sender's OAuth token (and not the recipient's)

- Updates DeliveryDetails and email Message classes to require a Django user on instantiation. This user provides the credentials to make DukeDS API calls
- Requires https://github.com/Duke-GCB/gcb-web-auth/pull/4
- Updates backends to ensure DukeDSUsers are linked to django Users whenever possible

Tested locally as described in #79:

1. Authenticating with DDS token (from DukeDSClient) still works
2. Authenticating with OAuth still works (from web login)
3. Authenticating with DDS Token (via command-line) creates a DukeDSUser and a Django user, both linked (but this will fail if Django user is not in a group for email templates yet)
4. Authenticating with OAuthToken (web) creates a django user but not a DukeDSUser
5. Authenticating with OAuthToken (web) when DukeDSUser exists creates a Django user and links it 

Fixes #89 