### PR TITLE
Adds a v2 API to support Ember-based UI

### DIFF
--- a/d4s2/settings_base.py
+++ b/d4s2/settings_base.py
@@ -38,6 +38,7 @@ INSTALLED_APPS = [
     'crispy_forms',
     'ownership',
     'simple_history',
+    'corsheaders',
 ]
 
 MIDDLEWARE_CLASSES = [
@@ -50,6 +51,7 @@ MIDDLEWARE_CLASSES = [
     'django.contrib.messages.middleware.MessageMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
     'simple_history.middleware.HistoryRequestMiddleware',
+    'corsheaders.middleware.CorsMiddleware',
 ]
 
 ROOT_URLCONF = 'd4s2.urls'

--- a/d4s2/settings_base.py
+++ b/d4s2/settings_base.py
@@ -33,6 +33,7 @@ INSTALLED_APPS = [
     'rest_framework',
     'rest_framework.authtoken',
     'd4s2_api',
+    'd4s2_api_v2',
     'gcb_web_auth',
     'switchboard',
     'crispy_forms',

--- a/d4s2/settings_base.py
+++ b/d4s2/settings_base.py
@@ -137,4 +137,15 @@ REST_FRAMEWORK = {
         'rest_framework.authentication.TokenAuthentication', # Allows users to authenticate with D4S2 rest_framework authtoken
         'rest_framework.authentication.SessionAuthentication',
     ),
+    'DEFAULT_RENDERER_CLASSES': (
+        'rest_framework.renderers.JSONRenderer',
+        'rest_framework.renderers.BrowsableAPIRenderer',
+        'data.renderers.JSONRootObjectRenderer',
+    ),
+    'DEFAULT_PARSER_CLASSES': (
+        'rest_framework.parsers.JSONParser',
+        'data.parsers.JSONRootObjectParser',
+    ),
+    'EXCEPTION_HANDLER': 'data.exception_handlers.switching_exception_handler',
+
 }

--- a/d4s2/settings_base.py
+++ b/d4s2/settings_base.py
@@ -150,3 +150,8 @@ REST_FRAMEWORK = {
     'EXCEPTION_HANDLER': 'data.exception_handlers.switching_exception_handler',
 
 }
+
+CORS_ORIGIN_WHITELIST = (
+    'localhost:4200',
+    '127.0.0.1:4200',
+)

--- a/d4s2/urls.py
+++ b/d4s2/urls.py
@@ -11,7 +11,7 @@ urlpatterns = [
     url(r'^api/v1/', include('d4s2_api.urls')),
     url(r'^api-auth/', include('rest_framework.urls',
                                namespace='rest_framework')),
-    url(r'^api-token-auth/', authtoken_views.obtain_auth_token),
+    url(r'^api-auth-token/', authtoken_views.obtain_auth_token),
     url(r'^accounts/login/$', auth_views.login, {'template_name': 'gcb_web_auth/login.html' }, name='login'),
     url(r'^accounts/logout/$', auth_views.logout, {'template_name': 'gcb_web_auth/logged_out.html' }, name='logout'),
     url(r'^accounts/login-local/$', auth_views.login, {'template_name': 'gcb_web_auth/login-local.html'}, name='login-local'),

--- a/d4s2/urls.py
+++ b/d4s2/urls.py
@@ -9,6 +9,7 @@ urlpatterns = [
     url(r'^ownership/', include('ownership.urls')),
     url(r'^auth/', include('gcb_web_auth.urls')),
     url(r'^api/v1/', include('d4s2_api.urls')),
+    url(r'^api/v2/', include('d4s2_api_v2.urls')),
     url(r'^api-auth/', include('rest_framework.urls',
                                namespace='rest_framework')),
     url(r'^api-auth-token/', authtoken_views.obtain_auth_token),

--- a/d4s2_api/serializers.py
+++ b/d4s2_api/serializers.py
@@ -42,6 +42,7 @@ class DeliverySerializer(serializers.HyperlinkedModelSerializer):
     class Meta:
         model = Delivery
         fields = ('id', 'url', 'project_id', 'from_user_id', 'to_user_id', 'state', 'transfer_id', 'user_message',)
+        resource_name = 'deliveries'
 
 
 class ShareSerializer(serializers.HyperlinkedModelSerializer):
@@ -53,6 +54,7 @@ class ShareSerializer(serializers.HyperlinkedModelSerializer):
     class Meta:
         model = Share
         fields = ('id', 'url', 'project_id', 'from_user_id', 'to_user_id', 'role', 'state', 'user_message',)
+        resource_name = 'shares'
 
 
 class UserSerializer(serializers.HyperlinkedModelSerializer):
@@ -61,3 +63,4 @@ class UserSerializer(serializers.HyperlinkedModelSerializer):
     class Meta:
         model = DukeDSUser
         fields = ('id', 'user_id', 'url', 'dds_id', 'full_name', 'email')
+        resource_name = 'users'

--- a/d4s2_api/serializers.py
+++ b/d4s2_api/serializers.py
@@ -42,7 +42,6 @@ class DeliverySerializer(serializers.HyperlinkedModelSerializer):
     class Meta:
         model = Delivery
         fields = ('id', 'url', 'project_id', 'from_user_id', 'to_user_id', 'state', 'transfer_id', 'user_message',)
-        resource_name = 'deliveries'
 
 
 class ShareSerializer(serializers.HyperlinkedModelSerializer):
@@ -54,7 +53,6 @@ class ShareSerializer(serializers.HyperlinkedModelSerializer):
     class Meta:
         model = Share
         fields = ('id', 'url', 'project_id', 'from_user_id', 'to_user_id', 'role', 'state', 'user_message',)
-        resource_name = 'shares'
 
 
 class UserSerializer(serializers.HyperlinkedModelSerializer):
@@ -63,4 +61,3 @@ class UserSerializer(serializers.HyperlinkedModelSerializer):
     class Meta:
         model = DukeDSUser
         fields = ('id', 'user_id', 'url', 'dds_id', 'full_name', 'email')
-        resource_name = 'users'

--- a/d4s2_api_v2/admin.py
+++ b/d4s2_api_v2/admin.py
@@ -1,0 +1,3 @@
+from django.contrib import admin
+
+# Register your models here.

--- a/d4s2_api_v2/api.py
+++ b/d4s2_api_v2/api.py
@@ -5,7 +5,7 @@ from rest_framework.decorators import detail_route
 from django.core.urlresolvers import reverse
 
 from d4s2_api_v2.serializers import *
-from models import *
+from d4s2_api_v2.models import *
 
 class DeliveryViewSet(viewsets.ReadOnlyModelViewSet):
 

--- a/d4s2_api_v2/api.py
+++ b/d4s2_api_v2/api.py
@@ -1,0 +1,33 @@
+from rest_framework import viewsets, status, permissions
+from rest_framework.exceptions import APIException, ValidationError
+from rest_framework.decorators import detail_route
+
+from django.core.urlresolvers import reverse
+
+from d4s2_api_v2.serializers import *
+from models import *
+
+class DeliveryViewSet(viewsets.ReadOnlyModelViewSet):
+
+    permission_classes = (permissions.IsAuthenticated,)
+    serializer_class = DeliverySerializer
+
+    def get_queryset(self):
+        return Delivery.objects.filter(from_user__user=self.request.user)
+
+class DukeDSUserViewSet(viewsets.ReadOnlyModelViewSet):
+
+    permission_classes = (permissions.IsAuthenticated,)
+    serializer_class = DukeDSUserSerializer
+    queryset = DukeDSUser.objects.all()
+
+class DukeDSProjectViewSet(viewsets.ReadOnlyModelViewSet):
+
+    permission_classes = (permissions.IsAuthenticated,)
+    serializer_class = DukeDSProjectSerializer
+
+    def get_queryset(self):
+        # Only show the projects that the authenticated user is delivering
+        return DukeDSProject.objects.filter(delivery__from_user__user=self.request.user)
+
+

--- a/d4s2_api_v2/apps.py
+++ b/d4s2_api_v2/apps.py
@@ -1,0 +1,7 @@
+from __future__ import unicode_literals
+
+from django.apps import AppConfig
+
+
+class D4S2ApiV2Config(AppConfig):
+    name = 'd4s2_api_v2'

--- a/d4s2_api_v2/models.py
+++ b/d4s2_api_v2/models.py
@@ -1,0 +1,1 @@
+from d4s2_api.models import Delivery, DukeDSUser, DukeDSProject

--- a/d4s2_api_v2/serializers.py
+++ b/d4s2_api_v2/serializers.py
@@ -1,7 +1,7 @@
 from django.contrib.auth.models import User
 from django.core.exceptions import ObjectDoesNotExist
 from django.utils.encoding import smart_text
-from models import Delivery, DukeDSUser, DukeDSProject
+from d4s2_api_v2.models import Delivery, DukeDSUser, DukeDSProject
 
 from rest_framework import serializers
 

--- a/d4s2_api_v2/serializers.py
+++ b/d4s2_api_v2/serializers.py
@@ -1,0 +1,28 @@
+from django.contrib.auth.models import User
+from django.core.exceptions import ObjectDoesNotExist
+from django.utils.encoding import smart_text
+from models import Delivery, DukeDSUser, DukeDSProject
+
+from rest_framework import serializers
+
+
+class DeliverySerializer(serializers.ModelSerializer):
+
+    class Meta:
+        model = Delivery
+        resource_name = 'deliveries'
+        fields = '__all__'
+
+class DukeDSUserSerializer(serializers.ModelSerializer):
+
+    class Meta:
+        model = DukeDSUser
+        resource_name = 'duke-ds-users'
+        fields = '__all__'
+
+class DukeDSProjectSerializer(serializers.ModelSerializer):
+
+    class Meta:
+        model = DukeDSProject
+        resource_name = 'duke-ds-projects'
+        fields = '__all__'

--- a/d4s2_api_v2/tests.py
+++ b/d4s2_api_v2/tests.py
@@ -1,0 +1,3 @@
+from django.test import TestCase
+
+# Create your tests here.

--- a/d4s2_api_v2/tests.py
+++ b/d4s2_api_v2/tests.py
@@ -1,3 +1,0 @@
-from django.test import TestCase
-
-# Create your tests here.

--- a/d4s2_api_v2/tests_api.py
+++ b/d4s2_api_v2/tests_api.py
@@ -32,18 +32,18 @@ class DeliveryAPITestCase(AuthenticatedResourceTestCase):
 
     def test_fails_unauthenticated(self):
         self.client.logout()
-        url = reverse('delivery-list')
+        url = reverse('v2-delivery-list')
         response = self.client.post(url, {}, format='json')
         self.assertUnauthorized(response)
 
     def test_is_readonly(self):
         d = Delivery.objects.create(project=self.project1, from_user=self.ddsuser1, to_user=self.ddsuser2,
                                     transfer_id=self.transfer_id1)
-        list_url = reverse('delivery-list')
+        list_url = reverse('v2-delivery-list')
         response = self.client.post(list_url , {}, format='json')
         self.assertNotAllowed(response)
 
-        detail_url = reverse('delivery-detail', args=(d.pk,))
+        detail_url = reverse('v2-delivery-detail', args=(d.pk,))
         response = self.client.delete(detail_url, format='json')
         self.assertNotAllowed(response)
 
@@ -55,7 +55,7 @@ class DeliveryAPITestCase(AuthenticatedResourceTestCase):
                                 transfer_id=self.transfer_id1)
         Delivery.objects.create(project=self.project2, from_user=self.ddsuser1, to_user=self.ddsuser2,
                                 transfer_id=self.transfer_id2)
-        url = reverse('delivery-list')
+        url = reverse('v2-delivery-list')
         response = self.client.get(url, format='json')
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(len(response.data), 2)
@@ -65,7 +65,7 @@ class DeliveryAPITestCase(AuthenticatedResourceTestCase):
                                     transfer_id=self.transfer_id1)
         Delivery.objects.create(project=self.project2, from_user=self.ddsuser1, to_user=self.ddsuser2,
                                 transfer_id=self.transfer_id2)
-        detail_url = reverse('delivery-detail', args=(d.pk,))
+        detail_url = reverse('v2-delivery-detail', args=(d.pk,))
         response = self.client.get(detail_url, format='json')
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.data.get('id'), d.pk)
@@ -77,7 +77,7 @@ class DeliveryAPITestCase(AuthenticatedResourceTestCase):
                                              transfer_id=self.transfer_id2)
         unrelated = Delivery.objects.create(project=self.project3, from_user=self.ddsuser2, to_user=self.ddsuser3,
                                              transfer_id=self.transfer_id3)
-        url = reverse('delivery-list')
+        url = reverse('v2-delivery-list')
         response = self.client.get(url, format='json')
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(len(response.data), 1)
@@ -91,17 +91,17 @@ class DukeDSUserAPITestCase(AuthenticatedResourceTestCase):
 
     def test_fails_unauthenticated(self):
         self.client.logout()
-        url = reverse('dukedsuser-list')
+        url = reverse('v2-dukedsuser-list')
         response = self.client.post(url, {}, format='json')
         self.assertUnauthorized(response)
 
     def test_api_is_readonly(self):
         d = DukeDSUser.objects.create(dds_id='test-user')
-        list_url = reverse('dukedsuser-list')
+        list_url = reverse('v2-dukedsuser-list')
         response = self.client.post(list_url , {}, format='json')
         self.assertNotAllowed(response)
 
-        detail_url = reverse('dukedsuser-detail', args=(d.pk,))
+        detail_url = reverse('v2-dukedsuser-detail', args=(d.pk,))
         response = self.client.delete(detail_url, format='json')
         self.assertNotAllowed(response)
 
@@ -111,7 +111,7 @@ class DukeDSUserAPITestCase(AuthenticatedResourceTestCase):
     def test_lists_all_users(self):
         model_ids = [u.pk for u in DukeDSUser.objects.all()]
         self.assertGreater(len(model_ids), 0)
-        url = reverse('dukedsuser-list')
+        url = reverse('v2-dukedsuser-list')
         response = self.client.get(url, format='json')
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(len(response.data), len(model_ids))
@@ -123,17 +123,17 @@ class DukeDSProjectAPITestCase(AuthenticatedResourceTestCase):
 
     def test_fails_unauthenticated(self):
         self.client.logout()
-        url = reverse('dukedsproject-list')
+        url = reverse('v2-dukedsproject-list')
         response = self.client.post(url, {}, format='json')
         self.assertUnauthorized(response)
 
     def test_api_is_readonly(self):
         p = DukeDSProject.objects.create(project_id='test-project', name='Test Project')
-        list_url = reverse('dukedsproject-list')
+        list_url = reverse('v2-dukedsproject-list')
         response = self.client.post(list_url , {}, format='json')
         self.assertNotAllowed(response)
 
-        detail_url = reverse('dukedsproject-detail', args=(p.pk,))
+        detail_url = reverse('v2-dukedsproject-detail', args=(p.pk,))
         response = self.client.delete(detail_url, format='json')
         self.assertNotAllowed(response)
 
@@ -152,7 +152,7 @@ class DukeDSProjectAPITestCase(AuthenticatedResourceTestCase):
         Delivery.objects.create(project=unrelated, from_user=self.ddsuser2, to_user=self.ddsuser3,
                                 transfer_id=self.transfer_id3)
 
-        list_url = reverse('dukedsproject-list')
+        list_url = reverse('v2-dukedsproject-list')
         response = self.client.get(list_url, format='json')
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         response_ids = [p['id'] for p in response.data]

--- a/d4s2_api_v2/tests_api.py
+++ b/d4s2_api_v2/tests_api.py
@@ -1,0 +1,161 @@
+from django.core.urlresolvers import reverse
+from rest_framework import status
+from django.contrib.auth.models import User as django_user
+from rest_framework.test import APITestCase
+from gcb_web_auth.tests_dukeds_auth import ResponseStatusCodeTestCase
+from d4s2_api_v2.models import *
+
+class AuthenticatedResourceTestCase(APITestCase, ResponseStatusCodeTestCase):
+    def setUp(self):
+        username = 'api_user'
+        password = 'secret'
+        self.user = django_user.objects.create_user(username, password=password, is_staff=True)
+        self.client.login(username=username, password=password)
+        self.ddsuser1 = DukeDSUser.objects.create(user=self.user, dds_id='user1')
+        self.ddsuser2 = DukeDSUser.objects.create(dds_id='user2')
+        self.ddsuser3 = DukeDSUser.objects.create(dds_id='user3')
+        self.project1 = DukeDSProject.objects.create(project_id='project1', name='Project 1')
+        self.project2 = DukeDSProject.objects.create(project_id='project2', name='Project 2')
+        self.project3 = DukeDSProject.objects.create(project_id='project3', name='Project 3')
+        self.transfer_id1 = 'abcd-1234'
+        self.transfer_id2 = 'efgh-5678'
+        self.transfer_id3 = 'ijkl-9012'
+
+    def assertNotAllowed(self, response):
+        # TODO: Move to ResponseStatusCodeTestCase
+        self.assertEqual(response.status_code, status.HTTP_405_METHOD_NOT_ALLOWED,
+                         'Got {}, expected 405 when method is not allowed'
+                         .format(response.status_code))
+
+
+class DeliveryAPITestCase(AuthenticatedResourceTestCase):
+
+    def test_fails_unauthenticated(self):
+        self.client.logout()
+        url = reverse('delivery-list')
+        response = self.client.post(url, {}, format='json')
+        self.assertUnauthorized(response)
+
+    def test_is_readonly(self):
+        d = Delivery.objects.create(project=self.project1, from_user=self.ddsuser1, to_user=self.ddsuser2,
+                                    transfer_id=self.transfer_id1)
+        list_url = reverse('delivery-list')
+        response = self.client.post(list_url , {}, format='json')
+        self.assertNotAllowed(response)
+
+        detail_url = reverse('delivery-detail', args=(d.pk,))
+        response = self.client.delete(detail_url, format='json')
+        self.assertNotAllowed(response)
+
+        response = self.client.put(detail_url, {}, format='json')
+        self.assertNotAllowed(response)
+
+    def test_lists_users_deliveries(self):
+        Delivery.objects.create(project=self.project1, from_user=self.ddsuser1, to_user=self.ddsuser2,
+                                transfer_id=self.transfer_id1)
+        Delivery.objects.create(project=self.project2, from_user=self.ddsuser1, to_user=self.ddsuser2,
+                                transfer_id=self.transfer_id2)
+        url = reverse('delivery-list')
+        response = self.client.get(url, format='json')
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(response.data), 2)
+
+    def test_gets_single_delivery(self):
+        d = Delivery.objects.create(project=self.project1, from_user=self.ddsuser1, to_user=self.ddsuser2,
+                                    transfer_id=self.transfer_id1)
+        Delivery.objects.create(project=self.project2, from_user=self.ddsuser1, to_user=self.ddsuser2,
+                                transfer_id=self.transfer_id2)
+        detail_url = reverse('delivery-detail', args=(d.pk,))
+        response = self.client.get(detail_url, format='json')
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data.get('id'), d.pk)
+
+    def test_lists_only_deliveries_sent_by_user(self):
+        sent = Delivery.objects.create(project=self.project1, from_user=self.ddsuser1, to_user=self.ddsuser2,
+                                           transfer_id=self.transfer_id1)
+        received = Delivery.objects.create(project=self.project2, from_user=self.ddsuser2, to_user=self.ddsuser1,
+                                             transfer_id=self.transfer_id2)
+        unrelated = Delivery.objects.create(project=self.project3, from_user=self.ddsuser2, to_user=self.ddsuser3,
+                                             transfer_id=self.transfer_id3)
+        url = reverse('delivery-list')
+        response = self.client.get(url, format='json')
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(response.data), 1)
+        delivery_ids = [d['id'] for d in response.data]
+        self.assertIn(sent.pk, delivery_ids)
+        self.assertNotIn(received.pk, delivery_ids)
+        self.assertNotIn(unrelated.pk, delivery_ids)
+
+
+class DukeDSUserAPITestCase(AuthenticatedResourceTestCase):
+
+    def test_fails_unauthenticated(self):
+        self.client.logout()
+        url = reverse('dukedsuser-list')
+        response = self.client.post(url, {}, format='json')
+        self.assertUnauthorized(response)
+
+    def test_api_is_readonly(self):
+        d = DukeDSUser.objects.create(dds_id='test-user')
+        list_url = reverse('dukedsuser-list')
+        response = self.client.post(list_url , {}, format='json')
+        self.assertNotAllowed(response)
+
+        detail_url = reverse('dukedsuser-detail', args=(d.pk,))
+        response = self.client.delete(detail_url, format='json')
+        self.assertNotAllowed(response)
+
+        response = self.client.put(detail_url, {}, format='json')
+        self.assertNotAllowed(response)
+
+    def test_lists_all_users(self):
+        model_ids = [u.pk for u in DukeDSUser.objects.all()]
+        self.assertGreater(len(model_ids), 0)
+        url = reverse('dukedsuser-list')
+        response = self.client.get(url, format='json')
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(response.data), len(model_ids))
+        api_ids = [u['id'] for u in response.data]
+        self.assertEqual(api_ids, model_ids)
+
+
+class DukeDSProjectAPITestCase(AuthenticatedResourceTestCase):
+
+    def test_fails_unauthenticated(self):
+        self.client.logout()
+        url = reverse('dukedsproject-list')
+        response = self.client.post(url, {}, format='json')
+        self.assertUnauthorized(response)
+
+    def test_api_is_readonly(self):
+        p = DukeDSProject.objects.create(project_id='test-project', name='Test Project')
+        list_url = reverse('dukedsproject-list')
+        response = self.client.post(list_url , {}, format='json')
+        self.assertNotAllowed(response)
+
+        detail_url = reverse('dukedsproject-detail', args=(p.pk,))
+        response = self.client.delete(detail_url, format='json')
+        self.assertNotAllowed(response)
+
+        response = self.client.put(detail_url, {}, format='json')
+        self.assertNotAllowed(response)
+
+    def test_lists_only_projects_user_is_delivering(self):
+        delivering = DukeDSProject.objects.create(project_id='delivering-project')
+        receiving = DukeDSProject.objects.create(project_id='receiving-project')
+        unrelated = DukeDSProject.objects.create(project_id='unrelated-project')
+
+        Delivery.objects.create(project=delivering, from_user=self.ddsuser1, to_user=self.ddsuser2,
+                                transfer_id=self.transfer_id1)
+        Delivery.objects.create(project=receiving, from_user=self.ddsuser2, to_user=self.ddsuser1,
+                                transfer_id=self.transfer_id2)
+        Delivery.objects.create(project=unrelated, from_user=self.ddsuser2, to_user=self.ddsuser3,
+                                transfer_id=self.transfer_id3)
+
+        list_url = reverse('dukedsproject-list')
+        response = self.client.get(list_url, format='json')
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        response_ids = [p['id'] for p in response.data]
+        self.assertIn(delivering.pk, response_ids)
+        self.assertNotIn(receiving.pk, response_ids)
+        self.assertNotIn(unrelated.pk, response_ids)

--- a/d4s2_api_v2/tests_serializers.py
+++ b/d4s2_api_v2/tests_serializers.py
@@ -1,0 +1,44 @@
+from django.test import TestCase
+from d4s2_api_v2.serializers import *
+from d4s2_api_v2.models import *
+
+class SerializerTestCase(TestCase):
+
+    def setUp(self):
+        self.project1 = DukeDSProject.objects.create(project_id='project1', name='Project 1')
+        self.ddsuser1 = DukeDSUser.objects.create(dds_id='user1', full_name='User One', email='user@host.com')
+        self.ddsuser2 = DukeDSUser.objects.create(dds_id='user2')
+        self.transferid1 = 'transfer-1'
+        self.delivery1 = Delivery.objects.create(project=self.project1,
+                                                 from_user=self.ddsuser1,
+                                                 to_user=self.ddsuser2,
+                                                 transfer_id=self.transferid1)
+
+
+class DeliverySerializerTestCase(SerializerTestCase):
+
+    def test_serializes_delivery_model(self):
+        serialized = DeliverySerializer(self.delivery1).data
+        self.assertEqual(serialized['id'], self.delivery1.pk)
+        self.assertEqual(serialized['project'], self.project1.pk)
+        self.assertEqual(serialized['from_user'], self.ddsuser1.pk)
+        self.assertEqual(serialized['to_user'], self.ddsuser2.pk)
+        self.assertEqual(serialized['transfer_id'], self.transferid1)
+
+
+class DukeDSUserSerializerTestCase(SerializerTestCase):
+
+    def test_serializes_dukedsuser_model(self):
+        serialized = DukeDSUserSerializer(self.ddsuser1).data
+        self.assertEqual(serialized['id'], self.ddsuser1.pk)
+        self.assertEqual(serialized['dds_id'], self.ddsuser1.dds_id)
+        self.assertEqual(serialized['full_name'], self.ddsuser1.full_name)
+        self.assertEqual(serialized['email'], self.ddsuser1.email)
+
+class DukeDSProjectSerializerTestCase(SerializerTestCase):
+
+    def test_serializes_dukedsproject_model(self):
+        serialized = DukeDSProjectSerializer(self.project1).data
+        self.assertEqual(serialized['id'], self.project1.pk)
+        self.assertEqual(serialized['project_id'], self.project1.project_id)
+        self.assertEqual(serialized['name'], self.project1.name)

--- a/d4s2_api_v2/urls.py
+++ b/d4s2_api_v2/urls.py
@@ -1,0 +1,12 @@
+from django.conf.urls import url, include
+from rest_framework import routers
+from d4s2_api_v2 import api
+
+router = routers.DefaultRouter()
+router.register(r'deliveries', api.DeliveryViewSet, 'delivery')
+router.register(r'duke-ds-users', api.DukeDSUserViewSet, 'dukedsuser')
+router.register(r'duke-ds-projects', api.DukeDSProjectViewSet, 'dukedsproject')
+
+urlpatterns = [
+    url(r'^', include(router.urls)),
+]

--- a/d4s2_api_v2/urls.py
+++ b/d4s2_api_v2/urls.py
@@ -3,9 +3,9 @@ from rest_framework import routers
 from d4s2_api_v2 import api
 
 router = routers.DefaultRouter()
-router.register(r'deliveries', api.DeliveryViewSet, 'delivery')
-router.register(r'duke-ds-users', api.DukeDSUserViewSet, 'dukedsuser')
-router.register(r'duke-ds-projects', api.DukeDSProjectViewSet, 'dukedsproject')
+router.register(r'deliveries', api.DeliveryViewSet, 'v2-delivery')
+router.register(r'duke-ds-users', api.DukeDSUserViewSet, 'v2-dukedsuser')
+router.register(r'duke-ds-projects', api.DukeDSProjectViewSet, 'v2-dukedsproject')
 
 urlpatterns = [
     url(r'^', include(router.urls)),

--- a/data/exception_handlers.py
+++ b/data/exception_handlers.py
@@ -1,5 +1,5 @@
 from rest_framework.views import exception_handler
-from renderers import JSONRootObjectRenderer
+from data.renderers import JSONRootObjectRenderer
 
 SOURCE_POINTER_PREFIX = '/data/attributes'
 

--- a/data/exception_handlers.py
+++ b/data/exception_handlers.py
@@ -1,0 +1,51 @@
+from rest_framework.views import exception_handler
+from renderers import JSONRootObjectRenderer
+
+SOURCE_POINTER_PREFIX = '/data/attributes'
+
+
+def switching_exception_handler(exc, context):
+    request = context.get('request')
+    handler = exception_handler
+    if request.accepted_media_type == JSONRootObjectRenderer.media_type:
+        handler = json_root_object_exception_handler
+    return handler(exc, context)
+
+
+def make_json_root_error(status_code, data, exc):
+    # JSON root errors should conform to JSONAPI: http://jsonapi.org/format/#error-objects
+    error = { 'status': status_code }
+    if isinstance(data, str):
+        error['detail'] = data
+    elif isinstance(data, dict):
+        if 'detail' in data:
+            error['detail'] = data['detail']
+        else:
+            for key in data.keys():
+                value = data[key]
+                error['source'] = {
+                    'pointer': '{}/{}'.format(SOURCE_POINTER_PREFIX, key)
+                }
+                error['detail'] = value
+        if 'id' in data:
+            error['id'] = data.get('id')
+    return error
+
+
+def json_root_object_exception_handler(exc, context):
+    # Call REST framework's default exception handler first,
+    # to get the standard error response.
+    response = exception_handler(exc, context)
+    # If exception_handler returns None, the exception has not been handled by rest_framework
+    # If we return None, Django responds with a 500 (and html in debug mode). So we should handle them and
+    # return appropriate responses. For now, we'll just return None from the handler to aid ongoing development
+    if response is None:
+        return None
+    # response.data may be list or a single object
+    if isinstance(response.data, list):
+        errors = [make_json_root_error(response.status_code, data, exc) for data in response.data]
+    else:
+        errors = [make_json_root_error(response.status_code, response.data, exc)]
+
+    response.data = {'errors': errors}
+    return response

--- a/data/parsers.py
+++ b/data/parsers.py
@@ -1,5 +1,5 @@
 from rest_framework.parsers import JSONParser, ParseError
-from renderers import JSONRootObjectRenderer
+from data.renderers import JSONRootObjectRenderer
 import six
 
 class JSONRootObjectParser(JSONParser):

--- a/data/parsers.py
+++ b/data/parsers.py
@@ -1,0 +1,37 @@
+from rest_framework.parsers import JSONParser, ParseError
+from renderers import JSONRootObjectRenderer
+import six
+
+class JSONRootObjectParser(JSONParser):
+    """
+    A parser that expects incoming content to be wrapped in a root object for compatibility with
+    Ember's DS.RESTAdapter. The root key should match a resource_name on a serializer's Meta class
+
+    Example:
+
+    {
+        "users": {
+            "name": "Ben Franklin",
+            "email": "bfranklin@usa.gov"
+        }
+    }
+
+    """
+    media_type = 'application/vnd.rootobject+json'
+    renderer_class = JSONRootObjectRenderer
+
+    def parse(self, stream, media_type=None, parser_context=None):
+        parsed = super(JSONRootObjectParser, self).parse(stream, media_type, parser_context)
+        view = parser_context.get('view')
+        try:
+            # Check that the serializer for the given route matches the resource name in the parsed data
+            resource_name = view.get_serializer().Meta.resource_name
+        except AttributeError as exc:
+            # When our serializer object has no resource name we don't know what to expect.
+            raise ParseError('JSON parse error - %s' % six.text_type(exc))
+        try:
+            return parsed[resource_name]
+        except KeyError as exc:
+            # When our resource_name is defined but not found in the data, we should not try to extract it
+            raise ParseError('JSON parse error - %s' % six.text_type(exc))
+

--- a/data/renderers.py
+++ b/data/renderers.py
@@ -1,0 +1,30 @@
+from rest_framework.renderers import JSONRenderer
+
+
+def response_is_error(response):
+    try:
+        return response.status_code / 100 in (4, 5)
+    except AttributeError:
+        return False
+
+
+class JSONRootObjectRenderer(JSONRenderer):
+    media_type = 'application/vnd.rootobject+json'
+    format = 'json-rootobject'
+
+    """
+    Requires an attribute of 'resource_name' defined in the serializer's Meta class
+    """
+    def render(self, data, accepted_media_type=None, renderer_context=None):
+        response_data = {}
+        view = renderer_context.get('view')
+        if response_is_error(renderer_context.get('response')):
+            response_data = data
+        else:
+            try:
+                resource_name = view.get_serializer().Meta.resource_name
+                response_data[resource_name] = data
+            except AttributeError:
+                response_data = data
+        response = super(JSONRootObjectRenderer, self).render(response_data, accepted_media_type, renderer_context)
+        return response

--- a/data/renderers.py
+++ b/data/renderers.py
@@ -1,6 +1,5 @@
 from rest_framework.renderers import JSONRenderer
 
-
 def response_is_error(response):
     try:
         return response.status_code / 100 in (4, 5)

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ django-extensions==1.7.9
 django-filter==0.13.0
 django-simple-history==1.8.1
 django-sslserver==0.19
-djangorestframework==3.3.3
+djangorestframework==3.4.7
 DukeDSClient==0.3.9
 enum34==1.1.6
 funcsigs==0.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -26,7 +26,6 @@ pickleshare==0.7.4
 prompt-toolkit==1.0.9
 psycopg2==2.6.1
 ptyprocess==0.5.1
-pycharm===debug
 Pygments==2.1.3
 PyJWT==1.4.2
 PyYAML==3.12

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,9 @@ appnope==0.1.0
 backports.shutil-get-terminal-size==1.0.0
 decorator==4.0.10
 Django==1.9.4
+django-cors-headers==2.1.0
 django-crispy-forms==1.6.0
+django-extensions==1.7.9
 django-filter==0.13.0
 django-simple-history==1.8.1
 django-sslserver==0.19
@@ -10,10 +12,12 @@ djangorestframework==3.3.3
 DukeDSClient==0.3.9
 enum34==1.1.6
 funcsigs==0.4
+future==0.16.0
 gcb-web-auth==0.7
 ipython==5.1.0
 ipython-genutils==0.1.0
 mock==1.3.0
+oauthlib==2.0.0
 passlib==1.6.5
 pathlib2==2.1.0
 pbr==1.8.1
@@ -22,8 +26,12 @@ pickleshare==0.7.4
 prompt-toolkit==1.0.9
 psycopg2==2.6.1
 ptyprocess==0.5.1
+pycharm===debug
 Pygments==2.1.3
+PyJWT==1.4.2
 PyYAML==3.12
+requests==2.12.3
+requests-oauthlib==0.7.0
 simplegeneric==0.8.1
 six==1.10.0
 traitlets==4.3.1


### PR DESCRIPTION
- Copies JSONRootObject parser/renderer/exception handler from bespin-api
- Adds 3 read-only v2 endpoints:
  - `/api/v2/deliveries/`
  - `/api/v2/duke-ds-projects/`
  - `/api/v2/duke-ds-users/`

This targets initial support for browsing deliveries in https://github.com/duke-gcb/datadelivery-ui. Apache configuration has not yet been updated, but this works for local development.
