### PR TITLE
Add delivery id to DDSProjectTransferSerializer

### DIFF
--- a/d4s2_api_v2/serializers.py
+++ b/d4s2_api_v2/serializers.py
@@ -35,6 +35,7 @@ class DDSProjectTransferSerializer(serializers.Serializer):
     to_users = DDSUserSerializer(many=True)
     from_user = DDSUserSerializer()
     project = DDSProjectSerializer()
+    delivery = serializers.UUIDField()
 
     class Meta:
         resource_name = 'duke-ds-project-transfers'

--- a/d4s2_api_v2/tests_api.py
+++ b/d4s2_api_v2/tests_api.py
@@ -269,6 +269,8 @@ class DDSProjectTransfersViewSetTestCase(AuthenticatedResourceTestCase):
     @patch('d4s2_api_v2.api.DDSUtil')
     def test_list_transfers(self, mock_dds_util):
         mock_response = Mock()
+        delivery = Delivery.objects.create(project_id='project1', from_user_id='user1', to_user_id='user2',
+                                           transfer_id='transfer1')
         mock_response.json.return_value = {
             'results': [
                 {
@@ -328,6 +330,7 @@ class DDSProjectTransfersViewSetTestCase(AuthenticatedResourceTestCase):
         self.assertEqual(transfer['to_users'][0]['id'], 'user1')
         self.assertEqual(transfer['from_user']['id'], 'user2')
         self.assertEqual(transfer['project']['name'], 'Mouse')
+        self.assertEqual(transfer['delivery'], str(delivery.id))
 
         transfer = response.data[1]
         self.assertEqual(transfer['id'], 'transfer2')
@@ -337,6 +340,7 @@ class DDSProjectTransfersViewSetTestCase(AuthenticatedResourceTestCase):
         self.assertEqual(transfer['to_users'][0]['id'], 'user1')
         self.assertEqual(transfer['from_user']['id'], 'user3')
         self.assertEqual(transfer['project']['name'], 'Rat')
+        self.assertEqual(transfer['delivery'], None)
 
     @patch('d4s2_api_v2.api.DDSUtil')
     def test_get_project(self, mock_dds_util):

--- a/switchboard/dds_util.py
+++ b/switchboard/dds_util.py
@@ -142,6 +142,14 @@ class DDSProjectTransfer(DDSBase):
         self.to_users = DDSUser.from_list(transfer_dict.get('to_users'))
         self.from_user = DDSUser(transfer_dict.get('from_user'))
         self.project = DDSProject(transfer_dict.get('project'))
+        self.delivery = DDSProjectTransfer._lookup_delivery_id(self.id)
+
+    @staticmethod
+    def _lookup_delivery_id(transfer_id):
+        delivery = Delivery.objects.filter(transfer_id=transfer_id).first()
+        if delivery:
+            return delivery.id
+        return None
 
     @staticmethod
     def fetch_list(dds_util):


### PR DESCRIPTION
Adds delivery to `duke-ds-project-transfer` payload.
Needed for https://github.com/Duke-GCB/datadelivery-ui/pull/9