### PR TITLE
remove D4S2OAuth2Backend

### DIFF
--- a/d4s2/settings_base.py
+++ b/d4s2/settings_base.py
@@ -97,7 +97,7 @@ AUTH_PASSWORD_VALIDATORS = [
 AUTHENTICATION_BACKENDS = [
     'django.contrib.auth.backends.ModelBackend',
     'd4s2_api.dukeds_auth.D4S2DukeDSAuthBackend',
-    'd4s2_api.dukeds_auth.D4S2OAuth2Backend',
+    'gcb_web_auth.backends.oauth.OAuth2Backend',
 ]
 
 # Internationalization

--- a/d4s2_api/dukeds_auth.py
+++ b/d4s2_api/dukeds_auth.py
@@ -24,23 +24,3 @@ class D4S2DukeDSTokenAuthentication(DukeDSTokenAuthentication):
     """
     def __init__(self):
         self.backend = D4S2DukeDSAuthBackend()
-
-
-class D4S2OAuth2Backend(OAuth2Backend):
-    """
-    Slight customization to connect User objects to existing DukeDSUser objects (by email)
-    """
-    def handle_new_user(self, user, details):
-        """
-        When saving a new user from OAuth, check to see if an unlinked DukeDSUser object exists, and link it
-        :param user: A django user, created after receiving OAuth details
-        :param details: A dictionary of OAuth user info
-        :return: None
-        """
-        try:
-            dukeds_user = DukeDSUser.objects.get(user=None, email=user.email)
-            dukeds_user.user = user
-            dukeds_user.save()
-        except DukeDSUser.DoesNotExist:
-            # Either user already linked or not found. Either way, don't do anything.
-            pass


### PR DESCRIPTION
This functionality is no longer necessary after https://github.com/Duke-GCB/D4S2/pull/105.
It also fails with an error related to a missing email field.

Fixes #120 