### PR TITLE
Update D4S2 to use gcb_web_auth.DDSEndpoint instead of DukeDSSettings

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,9 +23,14 @@ Installation - Local
 
         $ python manage.py createsuperuser
 
-6 . Create DukeDS settings
+6 . Register an application with a Duke DS instance and create a DDSEndpoint with the URLs, agent key, and provider id
 
-        $ python manage.py createddssettings https://api.dataservice.duke.edu/api/v1 https://dev.dataservice.duke.edu <openid
+        $ python manage.py createddsendpoint \
+          endpoint-name \
+          https://api.dataservice.duke.edu/api/v1 \
+          registered-application-agent-key \
+          https://api.dataservice.duke.edu \
+          openid-provider-id
 
 7. Start the app:
 

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Installation - Local
           endpoint-name \
           https://api.dataservice.duke.edu/api/v1 \
           registered-application-agent-key \
-          https://api.dataservice.duke.edu \
+          https://dataservice.duke.edu \
           openid-provider-id
 
 7. Start the app:

--- a/d4s2_api/admin.py
+++ b/d4s2_api/admin.py
@@ -1,6 +1,6 @@
 from django.contrib import admin
 from d4s2_api.models import *
-from gcb_web_auth.models import DukeDSSettings
+from gcb_web_auth.models import DDSEndpoint, DDSUserCredential
 from simple_history.admin import SimpleHistoryAdmin
 
 admin.site.register(EmailTemplate)
@@ -19,6 +19,7 @@ class DeliveryAdmin(SimpleHistoryAdmin):
 
 admin.site.register(Delivery, DeliveryAdmin)
 admin.site.register(DeliveryShareUser)
-admin.site.register(DukeDSSettings)
+admin.site.register(DDSEndpoint)
+admin.site.register(DDSUserCredential)
 admin.site.register(EmailTemplateSet)
 admin.site.register(UserEmailTemplateSet)

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,7 +14,7 @@ DukeDSClient==1.0.1
 enum34==1.1.6
 funcsigs==0.4
 future==0.16.0
-gcb-web-auth==0.7
+gcb-web-auth==0.9
 ipython==5.1.0
 ipython-genutils==0.1.0
 mock==1.3.0

--- a/switchboard/dds_util.py
+++ b/switchboard/dds_util.py
@@ -3,7 +3,7 @@ from ddsc.core.remotestore import RemoteStore
 from d4s2_api.models import EmailTemplate, Delivery
 from gcb_web_auth.backends.dukeds import make_auth_config
 from gcb_web_auth.utils import get_dds_token
-from gcb_web_auth.models import DukeDSSettings
+from gcb_web_auth.models import DDSEndpoint
 
 
 class DDSUtil(object):
@@ -32,8 +32,8 @@ class DDSUtil(object):
         return self.remote_store.fetch_remote_project(project.name, must_exist=True)
 
     def get_project_url(self, project_id):
-        duke_ds_settings = DukeDSSettings.objects.first()
-        return '{}/portal/#/project/{}'.format(duke_ds_settings.portal_root, project_id)
+        endpoint = DDSEndpoint.objects.first()
+        return '{}/portal/#/project/{}'.format(endpoint.portal_root, project_id)
 
     def add_user(self, user_id, project_id, auth_role):
         project = self.remote_store.fetch_remote_project_by_id(project_id)

--- a/switchboard/tests_ddsutil.py
+++ b/switchboard/tests_ddsutil.py
@@ -2,7 +2,7 @@ from django.test import TestCase
 from mock import patch, Mock, MagicMock
 from switchboard.dds_util import DDSUtil, DeliveryDetails
 from d4s2_api.models import User
-from gcb_web_auth.models import DukeDSSettings
+from gcb_web_auth.models import DDSEndpoint
 
 
 class DDSUtilTestCase(TestCase):
@@ -10,7 +10,7 @@ class DDSUtilTestCase(TestCase):
     def setUp(self):
         self.user = User.objects.create(username='ddsutil_user')
         self.user_id = 'abcd-1234-efgh-8876'
-        DukeDSSettings.objects.create(url='', portal_root='', openid_provider_id='')
+        DDSEndpoint.objects.create(api_root='', portal_root='', openid_provider_id='')
 
         patcher = patch('switchboard.dds_util.get_dds_token')
         mock_get_dds_token = patcher.start()


### PR DESCRIPTION
Tested with local checkout of [gcb_web_auth@include-ddsendpoint](https://github.com/Duke-GCB/gcb-web-auth/tree/include-ddsendpoint)

```
pip install ../gcb_web_auth --upgrade
python manage.py migrate
```

Visit admin and confirm DukeDSSettings has been converted to DDSEndpoint

WIP. Depends on merge and release of https://github.com/Duke-GCB/gcb-web-auth/pull/23