### PR TITLE
Update start-apache.sh script to use createddsendpoint

### DIFF
--- a/production/start-apache.sh
+++ b/production/start-apache.sh
@@ -9,7 +9,7 @@ if [ -f /etc/external/fixtures.json ]; then
 fi
 
 # Create/Update DukeDS configuration
-python manage.py createddssettings $D4S2_DDSCLIENT_URL $D4S2_DDSCLIENT_PORTAL_ROOT $D4S2_DDSCLIENT_OPENID_PROVIDER_ID
+python manage.py createddsendpoint "Duke Data Service" $D4S2_DDSCLIENT_URL $D4S2_DDSCLIENT_PORTAL_ROOT $D4S2_DDSCLIENT_AGENT_KEY $D4S2_DDSCLIENT_OPENID_PROVIDER_ID
 
 # Apache gets grumpy about PID files pre-existing
 rm -f /var/run/apache2/apache2.pid


### PR DESCRIPTION
Fixes #148

Requires D4S2_DDSCLIENT_AGENT_KEY environment variable set