### PR TITLE
Adds endpoint to get the current DukeDSUser

### DIFF
--- a/d4s2_api_v2/api.py
+++ b/d4s2_api_v2/api.py
@@ -118,6 +118,15 @@ class DDSUsersViewSet(DDSViewSet):
         dds_util = DDSUtil(self.request.user)
         return self._ds_operation(DDSUser.fetch_one, dds_util, dds_user_id)
 
+    @list_route(methods=['get'], url_path='current-dds-user')
+    def current_dds_user(self, request):
+        dds_util = DDSUtil(self.request.user)
+        remote_dds_user = dds_util.get_current_user()
+        # Hack, fields don't line up
+        current_dds_user = DDSUser.fetch_one(dds_util, remote_dds_user.id)
+        serializer = DDSUserSerializer(current_dds_user)
+        return Response(serializer.data, status=status.HTTP_200_OK)
+
 
 class DDSProjectsViewSet(DDSViewSet):
     """

--- a/d4s2_api_v2/api.py
+++ b/d4s2_api_v2/api.py
@@ -118,11 +118,13 @@ class DDSUsersViewSet(DDSViewSet):
         dds_util = DDSUtil(self.request.user)
         return self._ds_operation(DDSUser.fetch_one, dds_util, dds_user_id)
 
-    @list_route(methods=['get'], url_path='current-dds-user')
-    def current_dds_user(self, request):
+    @list_route(methods=['get'], url_path='current-duke-ds-user')
+    def current_duke_ds_user(self, request):
         dds_util = DDSUtil(self.request.user)
         remote_dds_user = dds_util.get_current_user()
-        # Hack, fields don't line up
+        # dds_util.get_current_user() returns a ddsc.core.remotestore.RemoteUser
+        # which does not have first_name and last_name fields, so we
+        # make a second API call through DDSUser
         current_dds_user = DDSUser.fetch_one(dds_util, remote_dds_user.id)
         serializer = DDSUserSerializer(current_dds_user)
         return Response(serializer.data, status=status.HTTP_200_OK)


### PR DESCRIPTION
Adds `/v2/duke-ds-users/current-duke-ds-user/` endpoint needed to address https://github.com/Duke-GCB/datadelivery-ui/issues/12

Can be simplified by adding fields to `ddsc.core.remotestore.RemoteUser` in DukeDSClient, will file issue for that enhancement.