### PR TITLE
Updates docker-compose for local development

### DIFF
--- a/d4s2/settings.docker
+++ b/d4s2/settings.docker
@@ -34,4 +34,4 @@ if os.getenv('D4S2_SMTP_HOST') is not None:
   EMAIL_BACKEND = 'django.core.mail.backends.smtp.EmailBackend'
   EMAIL_HOST = os.getenv('D4S2_SMTP_HOST')
 
-STATIC_ROOT='/usr/src/app/static'
+STATIC_ROOT='/usr/src/static'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,5 +18,16 @@ services:
     # docker-compose doesn't allow specifying the entrypoint while preserving
     # the Dockerfile's command
     command: python manage.py runserver 0.0.0.0:8000
+  tasks:
+    build: .
+    env_file: d4s2.env
+    depends_on:
+      - db
+    entrypoint:
+      - /usr/src/app/d4s2/wait-for-postgres.sh
+      - db
+    # docker-compose doesn't allow specifying the entrypoint while preserving
+    # the Dockerfile's command
+    command: python manage.py process_tasks
 volumes:
   postgres_data:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,10 +1,10 @@
-version: '2'
+version: '3'
 services:
   db:
     image: postgres
     env_file: d4s2.env
     volumes:
-      - ./dbdata:/var/lib/postgresql/data
+      - postgres_data:/var/lib/postgresql/data
   web:
     build: .
     image: dukegcb/d4s2
@@ -19,3 +19,5 @@ services:
     # docker-compose doesn't allow specifying the entrypoint while preserving
     # the Dockerfile's command
     command: python manage.py runserver 0.0.0.0:8000
+volumes:
+  postgres_data:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,6 +18,9 @@ services:
     # docker-compose doesn't allow specifying the entrypoint while preserving
     # the Dockerfile's command
     command: python manage.py runserver 0.0.0.0:8000
+    volumes:
+      - .:/usr/src/app
+      - ./d4s2/settings.docker:/usr/src/app/d4s2/settings.py
   tasks:
     build: .
     env_file: d4s2.env
@@ -29,5 +32,8 @@ services:
     # docker-compose doesn't allow specifying the entrypoint while preserving
     # the Dockerfile's command
     command: python manage.py process_tasks
+    volumes:
+      - .:/usr/src/app
+      - ./d4s2/settings.docker:/usr/src/app/d4s2/settings.py
 volumes:
   postgres_data:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,6 @@ services:
       - postgres_data:/var/lib/postgresql/data
   web:
     build: .
-    image: dukegcb/d4s2
     env_file: d4s2.env
     ports:
       - "8000:8000"


### PR DESCRIPTION
Updates docker-compose to simplify local development

- Uses compose file version 3
- Mounts source tree into `/usr/src/app`, preserving `settings.docker`
- Configures web container to build locally instead of pulling from docker hub (as docker hub is being phased out of this deployment)
- Adds docker-compose service to run background task processing
- sets postgres data volume to be a docker named volume