### PR TITLE
Adds delivery-previews API

### DIFF
--- a/d4s2_api/tests_models.py
+++ b/d4s2_api/tests_models.py
@@ -4,7 +4,6 @@ from django.test import TestCase
 from d4s2_api.models import *
 from django.contrib.auth.models import User
 import datetime
-import json
 
 
 class TransferBaseTestCase(TestCase):

--- a/d4s2_api_v2/api.py
+++ b/d4s2_api_v2/api.py
@@ -1,4 +1,4 @@
-from rest_framework import viewsets, permissions, status
+from rest_framework import viewsets, permissions, status, views
 from rest_framework.exceptions import APIException
 from rest_framework.decorators import list_route, detail_route
 from rest_framework.response import Response
@@ -6,7 +6,7 @@ from django.db.models import Q
 from django.core.urlresolvers import reverse
 from django_filters.rest_framework import DjangoFilterBackend
 from switchboard.dds_util import DDSUser, DDSProject, DDSProjectTransfer, DDSProjectPermissions
-from switchboard.dds_util import DDSUtil
+from switchboard.dds_util import DDSUtil, MessageFactory
 from switchboard.s3_util import S3BucketUtil
 from d4s2_api_v2.serializers import DDSUserSerializer, DDSProjectSerializer, DDSProjectTransferSerializer, \
     UserSerializer, S3EndpointSerializer, S3UserSerializer, S3BucketSerializer, S3DeliverySerializer, \
@@ -14,6 +14,7 @@ from d4s2_api_v2.serializers import DDSUserSerializer, DDSProjectSerializer, DDS
 from d4s2_api.models import DDSDelivery, S3Endpoint, S3User, S3UserTypes, S3Bucket, S3Delivery
 from d4s2_api_v1.api import AlreadyNotifiedException, get_force_param, DeliveryViewSet, build_accept_url
 from switchboard.s3_util import S3MessageFactory, S3Exception, S3NoSuchBucket, SendDeliveryOperation
+from d4s2_api_v1.serializers import DeliverySerializer
 
 
 class DataServiceUnavailable(APIException):
@@ -265,3 +266,45 @@ class S3DeliveryViewSet(viewsets.ModelViewSet):
         accept_url = build_accept_url(request, s3_delivery.transfer_id, 's3')
         SendDeliveryOperation.run(s3_delivery, accept_url)
         return self.retrieve(request)
+
+
+class PreviewDDSDelivery(object):
+    def __init__(self, from_user_id, to_user_id, project_id, user_message):
+        self.from_user_id = from_user_id
+        self.to_user_id = to_user_id
+        self.project_id = project_id
+        self.user_message = user_message
+        self.delivery_email_text = ''
+
+
+
+from rest_framework import serializers
+from switchboard.dds_util import DeliveryDetails
+
+class PreviewDDSDeliverySerializer(serializers.Serializer):
+
+    from_user_id = serializers.CharField(required=True)
+    to_user_id = serializers.CharField(required=True)
+    project_id = serializers.CharField(required=True)
+    user_message = serializers.CharField(allow_blank=True)
+    delivery_email_text = serializers.CharField(read_only=True)
+
+
+class DeliveryPreviewView(views.APIView):
+
+    permission_classes = (permissions.IsAuthenticated,)
+
+    def post(self, request):
+        # Deserialize a delivery from the incoming payload
+        serializer = PreviewDDSDeliverySerializer(data=request.data)
+        serializer.is_valid(True)
+        delivery_preview = PreviewDDSDelivery(**serializer.validated_data)
+
+        accept_url = 'accept-url-goes-here'
+        delivery_details = DeliveryDetails(delivery_preview, request.user)
+
+        message_factory = MessageFactory(delivery_details)
+        message = message_factory.make_delivery_message(accept_url)
+        delivery_preview.delivery_email_text = message.email_text
+        serializer = DeliverySerializer(delivery_preview)
+        return Response(serializer.data, status=status.HTTP_201_CREATED)

--- a/d4s2_api_v2/api.py
+++ b/d4s2_api_v2/api.py
@@ -5,14 +5,14 @@ from rest_framework.response import Response
 from django.db.models import Q
 from django_filters.rest_framework import DjangoFilterBackend
 from switchboard.dds_util import DDSUser, DDSProject, DDSProjectTransfer, DDSProjectPermissions
-from switchboard.dds_util import DDSUtil, DDSMessageFactory, DeliveryDetails
+from switchboard.dds_util import DDSUtil, DDSMessageFactory
 from switchboard.s3_util import S3BucketUtil
 from d4s2_api_v2.serializers import DDSUserSerializer, DDSProjectSerializer, DDSProjectTransferSerializer, \
     UserSerializer, S3EndpointSerializer, S3UserSerializer, S3BucketSerializer, S3DeliverySerializer, \
     DDSProjectPermissionSerializer, DDSDeliveryPreviewSerializer
 from d4s2_api.models import DDSDelivery, S3Endpoint, S3User, S3UserTypes, S3Bucket, S3Delivery
-from d4s2_api_v1.api import AlreadyNotifiedException, get_force_param, DeliveryViewSet, build_accept_url
-from switchboard.s3_util import S3MessageFactory, S3Exception, S3NoSuchBucket, SendDeliveryOperation
+from d4s2_api_v1.api import AlreadyNotifiedException, get_force_param, build_accept_url
+from switchboard.s3_util import S3Exception, S3NoSuchBucket, SendDeliveryOperation
 from d4s2_api_v2.models import DDSDeliveryPreview
 
 class DataServiceUnavailable(APIException):

--- a/d4s2_api_v2/api.py
+++ b/d4s2_api_v2/api.py
@@ -5,7 +5,7 @@ from rest_framework.response import Response
 from django.db.models import Q
 from django_filters.rest_framework import DjangoFilterBackend
 from switchboard.dds_util import DDSUser, DDSProject, DDSProjectTransfer, DDSProjectPermissions
-from switchboard.dds_util import DDSUtil, MessageFactory, DeliveryDetails
+from switchboard.dds_util import DDSUtil, DDSMessageFactory, DeliveryDetails
 from switchboard.s3_util import S3BucketUtil
 from d4s2_api_v2.serializers import DDSUserSerializer, DDSProjectSerializer, DDSProjectTransferSerializer, \
     UserSerializer, S3EndpointSerializer, S3UserSerializer, S3BucketSerializer, S3DeliverySerializer, \
@@ -277,8 +277,7 @@ class DeliveryPreviewView(generics.CreateAPIView):
         delivery_preview = DDSDeliveryPreview(**serializer.validated_data)
         accept_url = build_accept_url(request, delivery_preview.transfer_id, 'dds')
 
-        delivery_details = DeliveryDetails(delivery_preview, self.request.user)
-        message_factory = MessageFactory(delivery_details)
+        message_factory = DDSMessageFactory(delivery_preview, self.request.user)
         message = message_factory.make_delivery_message(accept_url)
         delivery_preview.delivery_email_text = message.email_text
 

--- a/d4s2_api_v2/api.py
+++ b/d4s2_api_v2/api.py
@@ -11,7 +11,7 @@ from d4s2_api_v2.serializers import DDSUserSerializer, DDSProjectSerializer, DDS
     UserSerializer, S3EndpointSerializer, S3UserSerializer, S3BucketSerializer, S3DeliverySerializer, \
     DDSProjectPermissionSerializer, DDSDeliveryPreviewSerializer
 from d4s2_api.models import DDSDelivery, S3Endpoint, S3User, S3UserTypes, S3Bucket, S3Delivery
-from d4s2_api_v1.api import AlreadyNotifiedException, get_force_param, build_accept_url
+from d4s2_api_v1.api import AlreadyNotifiedException, get_force_param, build_accept_url, DeliveryViewSet
 from switchboard.s3_util import S3Exception, S3NoSuchBucket, SendDeliveryOperation
 from d4s2_api_v2.models import DDSDeliveryPreview
 

--- a/d4s2_api_v2/api.py
+++ b/d4s2_api_v2/api.py
@@ -281,6 +281,6 @@ class DeliveryPreviewView(generics.CreateAPIView):
         message = message_factory.make_delivery_message(accept_url)
         delivery_preview.delivery_email_text = message.email_text
 
-        serializer = self.serializer_class(instance=delivery_preview, context=self.get_serializer_context())
+        serializer = self.get_serializer(instance=delivery_preview)
         headers = self.get_success_headers(serializer.data)
         return Response(serializer.data, status=status.HTTP_201_CREATED, headers=headers)

--- a/d4s2_api_v2/api.py
+++ b/d4s2_api_v2/api.py
@@ -275,7 +275,7 @@ class DeliveryPreviewView(generics.CreateAPIView):
         serializer.is_valid(raise_exception=True)
 
         delivery_preview = DDSDeliveryPreview(**serializer.validated_data)
-        accept_url = build_accept_url(request, None, 'dds')
+        accept_url = build_accept_url(request, delivery_preview.transfer_id, 'dds')
 
         delivery_details = DeliveryDetails(delivery_preview, self.request.user)
         message_factory = MessageFactory(delivery_details)

--- a/d4s2_api_v2/models.py
+++ b/d4s2_api_v2/models.py
@@ -6,4 +6,3 @@ class DDSDeliveryPreview(object):
         self.project_id = project_id
         self.user_message = user_message
         self.delivery_email_text = ''
-

--- a/d4s2_api_v2/models.py
+++ b/d4s2_api_v2/models.py
@@ -1,8 +1,13 @@
 
 class DDSDeliveryPreview(object):
-    def __init__(self, from_user_id, to_user_id, project_id, user_message):
+    """
+    A class to represent a delivery preview, without persistence.
+    Has many of the same properties as a Delivery, and can be provided to the email generation code
+    """
+    def __init__(self, from_user_id, to_user_id, project_id, transfer_id, user_message):
         self.from_user_id = from_user_id
         self.to_user_id = to_user_id
         self.project_id = project_id
+        self.transfer_id = transfer_id
         self.user_message = user_message
         self.delivery_email_text = ''

--- a/d4s2_api_v2/models.py
+++ b/d4s2_api_v2/models.py
@@ -1,1 +1,9 @@
-from d4s2_api.models import DDSDelivery, DDSDeliveryShareUser
+
+class DDSDeliveryPreview(object):
+    def __init__(self, from_user_id, to_user_id, project_id, user_message):
+        self.from_user_id = from_user_id
+        self.to_user_id = to_user_id
+        self.project_id = project_id
+        self.user_message = user_message
+        self.delivery_email_text = ''
+

--- a/d4s2_api_v2/serializers.py
+++ b/d4s2_api_v2/serializers.py
@@ -121,3 +121,16 @@ class S3DeliverySerializer(serializers.ModelSerializer):
         if from_user == to_user:
             raise serializers.ValidationError(str("You cannot send s3 delivery to yourself."))
         return data
+
+
+class DDSDeliveryPreviewSerializer(serializers.Serializer):
+
+    from_user_id = serializers.CharField(required=True)
+    to_user_id = serializers.CharField(required=True)
+    project_id = serializers.CharField(required=True)
+    user_message = serializers.CharField(allow_blank=True)
+    delivery_email_text = serializers.CharField(read_only=True)
+
+    class Meta:
+        resource_name = 'delivery-preview'
+

--- a/d4s2_api_v2/serializers.py
+++ b/d4s2_api_v2/serializers.py
@@ -124,9 +124,17 @@ class S3DeliverySerializer(serializers.ModelSerializer):
 
 
 class DDSDeliveryPreviewSerializer(serializers.Serializer):
+    """
+    A serializer to represent a delivery preview, allowing for
+    email generation before saving to database or creating a transfer in DukeDS
+    transfer_id must be provided but may be blank.
+    For new deliveries it won't be known before creating the transfer in DukeDS, but for
+    resending existing deliveries, it can be provided and will be used in the accept url
+    """
     from_user_id = serializers.CharField(required=True)
     to_user_id = serializers.CharField(required=True)
     project_id = serializers.CharField(required=True)
+    transfer_id = serializers.CharField(allow_blank=True)
     user_message = serializers.CharField(allow_blank=True)
     delivery_email_text = serializers.CharField(read_only=True)
 

--- a/d4s2_api_v2/serializers.py
+++ b/d4s2_api_v2/serializers.py
@@ -2,7 +2,7 @@ from rest_framework import serializers
 from django.contrib.auth.models import User
 from switchboard.dds_util import DDSUtil
 from d4s2_api.models import S3Endpoint, S3User, S3Bucket, S3Delivery
-
+from d4s2_api_v2.models import DDSDeliveryPreview
 
 class DDSUserSerializer(serializers.Serializer):
     """
@@ -124,7 +124,6 @@ class S3DeliverySerializer(serializers.ModelSerializer):
 
 
 class DDSDeliveryPreviewSerializer(serializers.Serializer):
-
     from_user_id = serializers.CharField(required=True)
     to_user_id = serializers.CharField(required=True)
     project_id = serializers.CharField(required=True)
@@ -133,4 +132,3 @@ class DDSDeliveryPreviewSerializer(serializers.Serializer):
 
     class Meta:
         resource_name = 'delivery-preview'
-

--- a/d4s2_api_v2/tests_api.py
+++ b/d4s2_api_v2/tests_api.py
@@ -1002,6 +1002,7 @@ class S3DeliveryViewSetTestCase(APITestCase):
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         mock_send_delivery_operation.run.assert_called_with(delivery, 'https://someurl.com')
 
+
 class DeliveryPreviewViewTestCase(APITestCase):
 
     def setUp(self):

--- a/d4s2_api_v2/tests_api.py
+++ b/d4s2_api_v2/tests_api.py
@@ -1075,4 +1075,3 @@ class DeliveryPreviewViewTestCase(APITestCase):
         url = reverse('v2-delivery_previews')
         response = self.client.post(url, data={}, format='json')
         self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
-

--- a/d4s2_api_v2/tests_models.py
+++ b/d4s2_api_v2/tests_models.py
@@ -1,0 +1,21 @@
+from django.test import TestCase
+from d4s2_api_v2.models import DDSDeliveryPreview
+
+
+class DDSDeliveryPreviewTestCase(TestCase):
+
+    def setUp(self):
+        self.preview = DDSDeliveryPreview(
+            from_user_id='from-user-1',
+            to_user_id='to-user-2',
+            project_id='project-3',
+            transfer_id='transfer-4',
+            user_message='User Message'
+        )
+
+    def test_initialize_object(self):
+        self.assertIsNotNone(self.preview)
+
+    def test_defaults_delivery_email_text(self):
+        self.assertEqual(self.preview.delivery_email_text, '')
+

--- a/d4s2_api_v2/tests_serializers.py
+++ b/d4s2_api_v2/tests_serializers.py
@@ -1,0 +1,37 @@
+from django.test import TestCase
+from d4s2_api_v2.models import DDSDeliveryPreview
+from d4s2_api_v2.serializers import DDSDeliveryPreviewSerializer
+from mock import MagicMock
+
+
+class DeliveryPreviewSerializerTestCase(TestCase):
+    def setUp(self):
+        self.data = {
+            'project_id': 'project-1234',
+            'from_user_id': 'user-5678',
+            'to_user_id': 'user-9999',
+            'user_message': '',
+            'transfer_id': ''
+        }
+
+    def test_validates(self):
+        serializer = DDSDeliveryPreviewSerializer(data=self.data)
+        self.assertTrue(serializer.is_valid())
+
+    def test_ignores_delivery_email_text(self):
+        self.data['delivery_email_text'] = 'Hello world'
+        serializer = DDSDeliveryPreviewSerializer(data=self.data)
+        self.assertTrue(serializer.is_valid())
+        self.assertNotIn('delivery_email_text', serializer.validated_data)
+
+    def test_invalid_without_user_message_field(self):
+        del self.data['user_message']
+        self.assertNotIn('user_message', self.data)
+        serializer = DDSDeliveryPreviewSerializer(data=self.data)
+        self.assertFalse(serializer.is_valid())
+
+    def test_invalid_without_transfer_id_field(self):
+        del self.data['transfer_id']
+        self.assertNotIn('transfer_id', self.data)
+        serializer = DDSDeliveryPreviewSerializer(data=self.data)
+        self.assertFalse(serializer.is_valid())

--- a/d4s2_api_v2/tests_serializers.py
+++ b/d4s2_api_v2/tests_serializers.py
@@ -1,7 +1,5 @@
 from django.test import TestCase
-from d4s2_api_v2.models import DDSDeliveryPreview
 from d4s2_api_v2.serializers import DDSDeliveryPreviewSerializer
-from mock import MagicMock
 
 
 class DeliveryPreviewSerializerTestCase(TestCase):

--- a/d4s2_api_v2/urls.py
+++ b/d4s2_api_v2/urls.py
@@ -15,4 +15,5 @@ router.register(r's3-deliveries', api.S3DeliveryViewSet, 'v2-s3delivery')
 
 urlpatterns = [
     url(r'^', include(router.urls)),
+    url(r'delivery-preview', api.DeliveryPreviewView.as_view(), name='v2-delivery_preview')
 ]

--- a/d4s2_api_v2/urls.py
+++ b/d4s2_api_v2/urls.py
@@ -15,5 +15,5 @@ router.register(r's3-deliveries', api.S3DeliveryViewSet, 'v2-s3delivery')
 
 urlpatterns = [
     url(r'^', include(router.urls)),
-    url(r'delivery-preview', api.DeliveryPreviewView.as_view(), name='v2-delivery_preview')
+    url(r'delivery-previews', api.DeliveryPreviewView.as_view(), name='v2-delivery_preview')
 ]

--- a/d4s2_api_v2/urls.py
+++ b/d4s2_api_v2/urls.py
@@ -15,5 +15,5 @@ router.register(r's3-deliveries', api.S3DeliveryViewSet, 'v2-s3delivery')
 
 urlpatterns = [
     url(r'^', include(router.urls)),
-    url(r'delivery-previews', api.DeliveryPreviewView.as_view(), name='v2-delivery_preview')
+    url(r'delivery-previews', api.DeliveryPreviewView.as_view(), name='v2-delivery_previews')
 ]

--- a/switchboard/dds_util.py
+++ b/switchboard/dds_util.py
@@ -303,9 +303,15 @@ class DeliveryDetails(object):
         to_user = self.get_to_user()
         project = self.get_project()
         project_url = self.get_project_url()
+        try:
+            transfer_id = str(self.delivery.transfer_id)
+        except AttributeError:
+            # Shares and previews will not yet have a transfer id
+            transfer_id = None
+
         return {
             'service_name': DDS_SERVICE_NAME,
-            'transfer_id': str(self.delivery.transfer_id),
+            'transfer_id': transfer_id,
             'from_name': from_user.full_name,
             'from_email': from_user.email,
             'to_name': to_user.full_name,

--- a/switchboard/dds_util.py
+++ b/switchboard/dds_util.py
@@ -234,7 +234,6 @@ class DeliveryDetails(object):
     def get_to_user(self):
         return DDSUser.fetch_one(self.ddsutil, self.delivery.to_user_id)
 
-
     def get_project(self):
         try:
             # Shares do not have a transfer id so fall back to reading based on project id

--- a/switchboard/dds_util.py
+++ b/switchboard/dds_util.py
@@ -234,10 +234,17 @@ class DeliveryDetails(object):
     def get_to_user(self):
         return DDSUser.fetch_one(self.ddsutil, self.delivery.to_user_id)
 
+
     def get_project(self):
         try:
-            transfer = DDSProjectTransfer.fetch_one(self.ddsutil, self.delivery.transfer_id)
-            return DDSProject(transfer.project_dict)
+            # Shares do not have a transfer id so fall back to reading based on project id
+            transfer_id = self.delivery.transfer_id
+            if not transfer_id:
+                # Delivery previews have the attribute, but may not have any value in it
+                raise AttributeError('transfer_id is not set')
+            else:
+                transfer = DDSProjectTransfer.fetch_one(self.ddsutil, self.delivery.transfer_id)
+                return DDSProject(transfer.project_dict)
         except AttributeError:
             # Shares do not have a transfer id so fall back to reading based on project id
             return DDSProject.fetch_one(self.ddsutil, self.delivery.project_id)
@@ -304,14 +311,14 @@ class DeliveryDetails(object):
         project = self.get_project()
         project_url = self.get_project_url()
         try:
-            transfer_id = str(self.delivery.transfer_id)
+            transfer_id = self.delivery.transfer_id or None
         except AttributeError:
-            # Shares and previews will not yet have a transfer id
+            # Shares will not yet have a transfer id
             transfer_id = None
 
         return {
             'service_name': DDS_SERVICE_NAME,
-            'transfer_id': transfer_id,
+            'transfer_id': str(transfer_id),
             'from_name': from_user.full_name,
             'from_email': from_user.email,
             'to_name': to_user.full_name,


### PR DESCRIPTION
Fixes #168 

Note that this is a separate endpoint that's not an action on an existing delivery. This way, the endpoint can be used to generate preview emails before a delivery record exists on the server and before a transfer is created in DukeDS.

- Adds endpoint `/api/v2/delivery-previews/`, supporting only a POST
- Clients should POST an object that serializes with `DDSDeliveryPreviewSerializer`.

See `d4s2_api_v2.tests_api.DeliveryPreviewViewTestCase.test_create_preview_with_transfer_id` for example structure