### PR TITLE
fix acceptance email bug

### DIFF
--- a/d4s2_api/tests_utils.py
+++ b/d4s2_api/tests_utils.py
@@ -65,7 +65,17 @@ class MessageFactoryTestCase(TestCase):
         mock_message.assert_called_with('bob@bob.com', 'joe@joe.com', 'actionsubject', 'actionbody', {})
 
     @patch('d4s2_api.utils.Message')
-    def test_make_processed_message(self, mock_message):
+    def test_make_processed_message_to_sender(self, mock_message):
         factory = MessageFactory(self.delivery_details)
-        factory.make_processed_message('accept', warning_message='warning details')
+        factory.make_processed_message('accepted', warning_message='warning details',
+                                       direction=MessageDirection.ToSender)
+        mock_message.assert_called_with('joe@joe.com', 'bob@bob.com', 'actionsubject', 'actionbody', {})
+        self.delivery_details.get_email_context.assert_called_with(None, 'accepted', '', 'warning details')
+
+    @patch('d4s2_api.utils.Message')
+    def test_make_processed_message_to_recipient(self, mock_message):
+        factory = MessageFactory(self.delivery_details)
+        factory.make_processed_message('accepted_recipient', warning_message='warning details',
+                                       direction=MessageDirection.ToRecipient)
         mock_message.assert_called_with('bob@bob.com', 'joe@joe.com', 'actionsubject', 'actionbody', {})
+        self.delivery_details.get_email_context.assert_called_with(None, 'accepted_recipient', '', 'warning details')

--- a/d4s2_api/tests_utils.py
+++ b/d4s2_api/tests_utils.py
@@ -67,15 +67,14 @@ class MessageFactoryTestCase(TestCase):
     @patch('d4s2_api.utils.Message')
     def test_make_processed_message_to_sender(self, mock_message):
         factory = MessageFactory(self.delivery_details)
-        factory.make_processed_message('accepted', warning_message='warning details',
-                                       direction=MessageDirection.ToSender)
+        factory.make_processed_message('accepted', MessageDirection.ToSender, warning_message='warning details')
         mock_message.assert_called_with('joe@joe.com', 'bob@bob.com', 'actionsubject', 'actionbody', {})
         self.delivery_details.get_email_context.assert_called_with(None, 'accepted', '', 'warning details')
 
     @patch('d4s2_api.utils.Message')
     def test_make_processed_message_to_recipient(self, mock_message):
         factory = MessageFactory(self.delivery_details)
-        factory.make_processed_message('accepted_recipient', warning_message='warning details',
-                                       direction=MessageDirection.ToRecipient)
+        factory.make_processed_message('accepted_recipient', MessageDirection.ToRecipient,
+                                       warning_message='warning details')
         mock_message.assert_called_with('bob@bob.com', 'joe@joe.com', 'actionsubject', 'actionbody', {})
         self.delivery_details.get_email_context.assert_called_with(None, 'accepted_recipient', '', 'warning details')

--- a/d4s2_api/utils.py
+++ b/d4s2_api/utils.py
@@ -48,9 +48,12 @@ class MessageFactory(object):
         templates = self.delivery_details.get_action_template_text('delivery')
         return self._make_message(templates, accept_url=accept_url)
 
-    def make_processed_message(self, process_type, warning_message=''):
+    def make_processed_message(self, process_type, warning_message='', direction=MessageDirection.ToRecipient):
         templates = self.delivery_details.get_action_template_text(process_type)
-        return self._make_message(templates, reason='', warning_message=warning_message)
+        return self._make_message(templates, reason='',
+                                  process_type=process_type,
+                                  direction=direction,
+                                  warning_message=warning_message)
 
     def _make_message(self, templates, accept_url=None, reason=None, process_type=None,
                       direction=MessageDirection.ToRecipient, warning_message=''):

--- a/d4s2_api/utils.py
+++ b/d4s2_api/utils.py
@@ -48,7 +48,7 @@ class MessageFactory(object):
         templates = self.delivery_details.get_action_template_text('delivery')
         return self._make_message(templates, accept_url=accept_url)
 
-    def make_processed_message(self, process_type, warning_message='', direction=MessageDirection.ToRecipient):
+    def make_processed_message(self, process_type, direction, warning_message=''):
         templates = self.delivery_details.get_action_template_text(process_type)
         return self._make_message(templates, reason='',
                                   process_type=process_type,

--- a/switchboard/dds_util.py
+++ b/switchboard/dds_util.py
@@ -447,8 +447,8 @@ class DDSDeliveryType:
         warning_message = delivery_util.get_warning_message()
         message_factory = DDSMessageFactory(delivery, user)
         message = message_factory.make_processed_message('accepted',
-                                                         warning_message=warning_message,
-                                                         direction=MessageDirection.ToSender)
+                                                         MessageDirection.ToSender,
+                                                         warning_message=warning_message)
         message.send()
         delivery.mark_accepted(user.get_username(), message.email_text)
         return warning_message

--- a/switchboard/dds_util.py
+++ b/switchboard/dds_util.py
@@ -5,7 +5,7 @@ from gcb_web_auth.backends.dukeds import make_auth_config
 from gcb_web_auth.utils import get_dds_token, get_dds_config_for_credentials
 from gcb_web_auth.models import DDSEndpoint, DDSUserCredential
 from ddsc.core.ddsapi import DataServiceError
-from d4s2_api.utils import MessageFactory
+from d4s2_api.utils import MessageFactory, MessageDirection
 
 SHARE_IN_RESPONSE_TO_DELIVERY_MSG = 'Shared in response to project delivery.'
 
@@ -275,13 +275,6 @@ class DeliveryDetails(object):
         else:
             raise RuntimeError('No email template found')
 
-    def get_delivery(self):
-        transfer_id = self.get_transfer_id()
-        if transfer_id:
-            project_transfer = self.ddsutil.get_project_transfer(transfer_id)
-            self.delivery.update_state_from_project_transfer(project_transfer)
-        return self.delivery
-
     @classmethod
     def from_transfer_id(self, transfer_id, user):
         """
@@ -453,7 +446,9 @@ class DDSDeliveryType:
         delivery_util.give_sender_permission()
         warning_message = delivery_util.get_warning_message()
         message_factory = DDSMessageFactory(delivery, user)
-        message = message_factory.make_processed_message('accepted', warning_message=warning_message)
+        message = message_factory.make_processed_message('accepted',
+                                                         warning_message=warning_message,
+                                                         direction=MessageDirection.ToSender)
         message.send()
         delivery.mark_accepted(user.get_username(), message.email_text)
         return warning_message

--- a/switchboard/dds_util.py
+++ b/switchboard/dds_util.py
@@ -276,6 +276,10 @@ class DeliveryDetails(object):
             raise RuntimeError('No email template found')
 
     def get_delivery(self):
+        transfer_id = self.get_transfer_id()
+        if transfer_id:
+            project_transfer = self.ddsutil.get_project_transfer(transfer_id)
+            self.delivery.update_state_from_project_transfer(project_transfer)
         return self.delivery
 
     @classmethod

--- a/switchboard/s3_util.py
+++ b/switchboard/s3_util.py
@@ -1,6 +1,6 @@
 from d4s2_api.models import S3Delivery, EmailTemplate, S3User, S3UserTypes, S3DeliveryError, State, S3ObjectManifest, \
     EmailTemplateException
-from d4s2_api.utils import MessageFactory
+from d4s2_api.utils import MessageFactory, MessageDirection
 import boto3
 import botocore
 from background_task import background
@@ -159,9 +159,6 @@ class S3DeliveryDetails(object):
     def __init__(self, s3_delivery, user):
         self.s3_delivery = s3_delivery
         self.user = user
-
-    def get_delivery(self):
-        return self.s3_delivery
 
     def get_from_user(self):
         return self.s3_delivery.from_user.user
@@ -407,7 +404,7 @@ class S3TransferOperation(S3Operation):
         :param warning_message: str: warning that may have occurred during the transfer operation
         """
         print("Notifying sender delivery {} has been accepted.".format(self.delivery.id))
-        message = self.make_processed_message('accepted', warning_message)
+        message = self.make_processed_message('accepted', warning_message, direction=MessageDirection.ToSender)
         message.send()
         self.background_funcs.notify_receiver_transfer_complete(self.delivery.id, warning_message, message.email_text)
 

--- a/switchboard/s3_util.py
+++ b/switchboard/s3_util.py
@@ -416,7 +416,8 @@ class S3TransferOperation(S3Operation):
         :param sender_accepted_email_text: str: text of email message sent to recipient
         """
         print("Notifying receiver transfer of delivery {} is complete.".format(self.delivery.id))
-        message = self.make_processed_message('accepted_recipient', warning_message)
+        message = self.make_processed_message('accepted_recipient', warning_message,
+                                              direction=MessageDirection.ToRecipient)
         message.send()
         self.background_funcs.mark_delivery_complete(self.delivery.id,
                                                      sender_accepted_email_text,
@@ -434,15 +435,16 @@ class S3TransferOperation(S3Operation):
                                     sender_accepted_email_text,
                                     recipient_accepted_email_text)
 
-    def make_processed_message(self, process_type, warning_message):
+    def make_processed_message(self, process_type, warning_message, direction):
         """
         Create email message based on email template settings for the delivery from user and process_type.
         :param process_type: str: name of the template to return
         :param warning_message: str: warning message from s3 transfer
+        :param direction: str: MessageDirection
         :return: utils.Message: email message
         """
         message_factory = S3MessageFactory(self.delivery, self.from_user)
-        return message_factory.make_processed_message(process_type, warning_message=warning_message)
+        return message_factory.make_processed_message(process_type, warning_message=warning_message, direction=direction)
 
     def ensure_transferring(self):
         """

--- a/switchboard/s3_util.py
+++ b/switchboard/s3_util.py
@@ -444,7 +444,7 @@ class S3TransferOperation(S3Operation):
         :return: utils.Message: email message
         """
         message_factory = S3MessageFactory(self.delivery, self.from_user)
-        return message_factory.make_processed_message(process_type, warning_message=warning_message, direction=direction)
+        return message_factory.make_processed_message(process_type, direction, warning_message=warning_message)
 
     def ensure_transferring(self):
         """

--- a/switchboard/tests_ddsutil.py
+++ b/switchboard/tests_ddsutil.py
@@ -333,7 +333,7 @@ class DDSDeliveryTypeTestCase(TestCase):
         ])
 
         make_processed_message = mock_dds_message_factory.return_value.make_processed_message
-        make_processed_message.assert_called_with('accepted', warning_message='', direction=MessageDirection.ToSender)
+        make_processed_message.assert_called_with('accepted', MessageDirection.ToSender, warning_message='')
         make_processed_message.return_value.send.assert_called_with()
         mock_delivery.mark_accepted.assert_called_with(
             mock_user.get_username.return_value,

--- a/switchboard/tests_ddsutil.py
+++ b/switchboard/tests_ddsutil.py
@@ -227,40 +227,6 @@ class TestDeliveryDetails(TestCase):
         mock_dds_project.assert_called_with(mock_transfer.project_dict)
         mock_dds_project.fetch_one.assert_not_called()
 
-    @patch('switchboard.dds_util.DDSUtil')
-    def test_get_delivery_updates_from_transfer_status_accepted(self, mock_ddsutil):
-        delivery = DDSDelivery.objects.create(project_id='project1',
-                                              from_user_id='user1',
-                                              to_user_id='user2',
-                                              transfer_id='transfer1')
-
-        user = Mock()
-        mock_ddsutil.return_value.get_project_transfer.return_value = {'status': 'accepted'}
-
-        details = DeliveryDetails(delivery, user)
-        fetched_delivery = details.get_delivery()
-        self.assertEqual(fetched_delivery.state, State.ACCEPTED)
-        self.assertEqual(DDSDelivery.objects.get(id=delivery.id).state, State.ACCEPTED)
-
-    @patch('switchboard.dds_util.DDSUtil')
-    def test_get_delivery_updates_from_transfer_status_rejected(self, mock_ddsutil):
-        delivery = DDSDelivery.objects.create(project_id='project1',
-                                              from_user_id='user1',
-                                              to_user_id='user2',
-                                              transfer_id='transfer1')
-
-        user = Mock()
-        mock_ddsutil.return_value.get_project_transfer.return_value = {
-            'status': 'rejected',
-            'status_comment': 'wrong user'
-        }
-
-        details = DeliveryDetails(delivery, user)
-        fetched_delivery = details.get_delivery()
-        self.assertEqual(fetched_delivery.state, State.DECLINED)
-        self.assertEqual(fetched_delivery.decline_reason, 'wrong user')
-        self.assertEqual(DDSDelivery.objects.get(id=delivery.id).state, State.DECLINED)
-
 
 class DeliveryUtilTestCase(TestCase):
     def setUp(self):

--- a/switchboard/tests_ddsutil.py
+++ b/switchboard/tests_ddsutil.py
@@ -2,7 +2,7 @@ from django.test import TestCase
 from mock import patch, Mock, MagicMock, call
 from switchboard.dds_util import DDSUtil, DeliveryDetails, DeliveryUtil, DDSDeliveryType, \
     SHARE_IN_RESPONSE_TO_DELIVERY_MSG, PROJECT_ADMIN_ID, DDSProject, DDSProjectPermissions, \
-    DDS_PERMISSIONS_ID_SEP
+    DDS_PERMISSIONS_ID_SEP, MessageDirection
 from d4s2_api.models import User, Share, State, DDSDeliveryShareUser, DDSDelivery, ShareRole
 from gcb_web_auth.models import DDSEndpoint
 
@@ -333,7 +333,7 @@ class DDSDeliveryTypeTestCase(TestCase):
         ])
 
         make_processed_message = mock_dds_message_factory.return_value.make_processed_message
-        make_processed_message.assert_called_with('accepted', warning_message='')
+        make_processed_message.assert_called_with('accepted', warning_message='', direction=MessageDirection.ToSender)
         make_processed_message.return_value.send.assert_called_with()
         mock_delivery.mark_accepted.assert_called_with(
             mock_user.get_username.return_value,

--- a/switchboard/tests_ddsutil.py
+++ b/switchboard/tests_ddsutil.py
@@ -240,7 +240,7 @@ class TestDeliveryDetails(TestCase):
         details = DeliveryDetails(delivery, user)
         fetched_delivery = details.get_delivery()
         self.assertEqual(fetched_delivery.state, State.ACCEPTED)
-        self.assertEqual(DDSDelivery.objects.get(delivery.id).state, State.ACCEPTED)
+        self.assertEqual(DDSDelivery.objects.get(id=delivery.id).state, State.ACCEPTED)
 
     @patch('switchboard.dds_util.DDSUtil')
     def test_get_delivery_updates_from_transfer_status_rejected(self, mock_ddsutil):
@@ -250,12 +250,16 @@ class TestDeliveryDetails(TestCase):
                                               transfer_id='transfer1')
 
         user = Mock()
-        mock_ddsutil.return_value.get_project_transfer.return_value = {'status': 'rejected'}
+        mock_ddsutil.return_value.get_project_transfer.return_value = {
+            'status': 'rejected',
+            'status_comment': 'wrong user'
+        }
 
         details = DeliveryDetails(delivery, user)
         fetched_delivery = details.get_delivery()
         self.assertEqual(fetched_delivery.state, State.REJECTED)
-        self.assertEqual(DDSDelivery.objects.get(delivery.id).state, State.REJECTED)
+        self.assertEqual(fetched_delivery.decline_reason, 'wrong user')
+        self.assertEqual(DDSDelivery.objects.get(id=delivery.id).state, State.REJECTED)
 
 
 class DeliveryUtilTestCase(TestCase):

--- a/switchboard/tests_ddsutil.py
+++ b/switchboard/tests_ddsutil.py
@@ -257,9 +257,9 @@ class TestDeliveryDetails(TestCase):
 
         details = DeliveryDetails(delivery, user)
         fetched_delivery = details.get_delivery()
-        self.assertEqual(fetched_delivery.state, State.REJECTED)
+        self.assertEqual(fetched_delivery.state, State.DECLINED)
         self.assertEqual(fetched_delivery.decline_reason, 'wrong user')
-        self.assertEqual(DDSDelivery.objects.get(id=delivery.id).state, State.REJECTED)
+        self.assertEqual(DDSDelivery.objects.get(id=delivery.id).state, State.DECLINED)
 
 
 class DeliveryUtilTestCase(TestCase):

--- a/switchboard/tests_ddsutil.py
+++ b/switchboard/tests_ddsutil.py
@@ -227,6 +227,36 @@ class TestDeliveryDetails(TestCase):
         mock_dds_project.assert_called_with(mock_transfer.project_dict)
         mock_dds_project.fetch_one.assert_not_called()
 
+    @patch('switchboard.dds_util.DDSUtil')
+    def test_get_delivery_updates_from_transfer_status_accepted(self, mock_ddsutil):
+        delivery = DDSDelivery.objects.create(project_id='project1',
+                                              from_user_id='user1',
+                                              to_user_id='user2',
+                                              transfer_id='transfer1')
+
+        user = Mock()
+        mock_ddsutil.return_value.get_project_transfer.return_value = {'status': 'accepted'}
+
+        details = DeliveryDetails(delivery, user)
+        fetched_delivery = details.get_delivery()
+        self.assertEqual(fetched_delivery.state, State.ACCEPTED)
+        self.assertEqual(DDSDelivery.objects.get(delivery.id).state, State.ACCEPTED)
+
+    @patch('switchboard.dds_util.DDSUtil')
+    def test_get_delivery_updates_from_transfer_status_rejected(self, mock_ddsutil):
+        delivery = DDSDelivery.objects.create(project_id='project1',
+                                              from_user_id='user1',
+                                              to_user_id='user2',
+                                              transfer_id='transfer1')
+
+        user = Mock()
+        mock_ddsutil.return_value.get_project_transfer.return_value = {'status': 'rejected'}
+
+        details = DeliveryDetails(delivery, user)
+        fetched_delivery = details.get_delivery()
+        self.assertEqual(fetched_delivery.state, State.REJECTED)
+        self.assertEqual(DDSDelivery.objects.get(delivery.id).state, State.REJECTED)
+
 
 class DeliveryUtilTestCase(TestCase):
     def setUp(self):

--- a/switchboard/tests_s3_util.py
+++ b/switchboard/tests_s3_util.py
@@ -117,7 +117,6 @@ class S3DeliveryUtilTestCase(S3DeliveryTestBase):
 class S3DeliveryDetailsTestCase(S3DeliveryTestBase):
     def test_simple_getters(self):
         s3_delivery_details = S3DeliveryDetails(self.s3_delivery, self.from_user)
-        self.assertEqual(s3_delivery_details.get_delivery(), self.s3_delivery)
         self.assertEqual(s3_delivery_details.get_from_user(), self.from_user)
         self.assertEqual(s3_delivery_details.get_to_user(), self.to_user)
 

--- a/switchboard/tests_s3_util.py
+++ b/switchboard/tests_s3_util.py
@@ -438,7 +438,7 @@ class S3TransferOperationTestCase(S3DeliveryTestBase):
 
         self.s3_delivery.refresh_from_db()
         mock_s3_message_factory.return_value.make_processed_message.assert_called_with(
-            'accepted', warning_message='oops', direction=MessageDirection.ToSender)
+            'accepted', MessageDirection.ToSender, warning_message='oops')
         self.assertTrue(mock_message.send.called)
         operation.background_funcs.notify_receiver_transfer_complete.assert_called_with(
             self.s3_delivery.id, 'oops', 'sender email')
@@ -455,7 +455,7 @@ class S3TransferOperationTestCase(S3DeliveryTestBase):
 
         self.s3_delivery.refresh_from_db()
         mock_s3_message_factory.return_value.make_processed_message.assert_called_with(
-            'accepted_recipient', warning_message='oops', direction=MessageDirection.ToRecipient)
+            'accepted_recipient', MessageDirection.ToRecipient, warning_message='oops')
         self.assertTrue(mock_message.send.called)
         operation.background_funcs.mark_delivery_complete.assert_called_with(
             self.s3_delivery.id, 'sender email', 'receiver email')
@@ -474,11 +474,11 @@ class S3TransferOperationTestCase(S3DeliveryTestBase):
     @patch('switchboard.s3_util.S3MessageFactory')
     def test_make_processed_message(self, mock_s3_message_factory, mock_s3_delivery_type, mock_s3_delivery):
         operation = S3TransferOperation(delivery_id='delivery1')
-        message = operation.make_processed_message(process_type='accepted', warning_message='warning msg',
-                                                   direction=MessageDirection.ToSender)
+        message = operation.make_processed_message(process_type='accepted', direction=MessageDirection.ToSender,
+                                                   warning_message='warning msg')
         self.assertEqual(message, mock_s3_message_factory.return_value.make_processed_message.return_value)
         mock_s3_message_factory.return_value.make_processed_message.assert_called_with(
-            'accepted', warning_message='warning msg', direction=MessageDirection.ToSender
+            'accepted', MessageDirection.ToSender, warning_message='warning msg'
         )
 
     @patch('switchboard.s3_util.S3Delivery')

--- a/switchboard/tests_s3_util.py
+++ b/switchboard/tests_s3_util.py
@@ -3,7 +3,7 @@ from mock import patch, Mock, call
 from d4s2_api.models import S3Bucket, S3User, S3UserTypes, S3Delivery, User, S3Endpoint, State
 from switchboard.s3_util import S3Resource, S3DeliveryUtil, S3DeliveryDetails, S3BucketUtil, \
     S3NoSuchBucket, S3DeliveryType, S3TransferOperation, S3DeliveryError, SendDeliveryBackgroundFunctions, \
-    SendDeliveryOperation, S3NotRecipientException
+    SendDeliveryOperation, S3NotRecipientException, MessageDirection
 
 
 class S3DeliveryTestBase(TestCase):
@@ -438,7 +438,7 @@ class S3TransferOperationTestCase(S3DeliveryTestBase):
 
         self.s3_delivery.refresh_from_db()
         mock_s3_message_factory.return_value.make_processed_message.assert_called_with(
-            'accepted', warning_message='oops')
+            'accepted', warning_message='oops', direction=MessageDirection.ToSender)
         self.assertTrue(mock_message.send.called)
         operation.background_funcs.notify_receiver_transfer_complete.assert_called_with(
             self.s3_delivery.id, 'oops', 'sender email')
@@ -455,7 +455,7 @@ class S3TransferOperationTestCase(S3DeliveryTestBase):
 
         self.s3_delivery.refresh_from_db()
         mock_s3_message_factory.return_value.make_processed_message.assert_called_with(
-            'accepted_recipient', warning_message='oops')
+            'accepted_recipient', warning_message='oops', direction=MessageDirection.ToRecipient)
         self.assertTrue(mock_message.send.called)
         operation.background_funcs.mark_delivery_complete.assert_called_with(
             self.s3_delivery.id, 'sender email', 'receiver email')
@@ -474,10 +474,11 @@ class S3TransferOperationTestCase(S3DeliveryTestBase):
     @patch('switchboard.s3_util.S3MessageFactory')
     def test_make_processed_message(self, mock_s3_message_factory, mock_s3_delivery_type, mock_s3_delivery):
         operation = S3TransferOperation(delivery_id='delivery1')
-        message = operation.make_processed_message(process_type='accepted', warning_message='warning msg')
+        message = operation.make_processed_message(process_type='accepted', warning_message='warning msg',
+                                                   direction=MessageDirection.ToSender)
         self.assertEqual(message, mock_s3_message_factory.return_value.make_processed_message.return_value)
         mock_s3_message_factory.return_value.make_processed_message.assert_called_with(
-            'accepted', warning_message='warning msg'
+            'accepted', warning_message='warning msg', direction=MessageDirection.ToSender
         )
 
     @patch('switchboard.s3_util.S3Delivery')


### PR DESCRIPTION
Changes `MessageFactory. make_processed_message` to receive MessageDirection and pass process_type to `_make_message`. So callers can direct emails to the appropriate user (sender or recipient) and process type for accepted messages will not be lost.

Removes unused `get_delivery()` method from `DeliveryDetails` and` S3DeliveryDetails`.

Fixes #177 