### PR TITLE
Remove hard coded migrate

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,9 +72,13 @@ Installation - Docker Compose Development
 
         $ docker-compose -f docker-compose.dev.yml build
 
+5. Run migrations to setup the database
+
+        $ docker-compose -f docker-compose.dev.yml run app python manage.py migrate
+
 5. Create a superuser (A user account is required for making authenticated API requests)
 
-        $ docker-compose -f docker-compose.dev.yml run web python manage.py createsuperuser
+        $ docker-compose -f docker-compose.dev.yml run app python manage.py createsuperuser
 
 6. Start the app:
 

--- a/run.sh
+++ b/run.sh
@@ -4,22 +4,5 @@
 
 set -e
 
-if [ -z "$POSTGRES_HOST" ]; then
-  echo "ERROR: Please set POSTGRES_HOST"
-  exit 1
-fi
-
-# 1. Wait for postgres to be ready
-until pg_isready -h "$POSTGRES_HOST"; do
-  >&2 echo "Postgres is unavailable - sleeping"
-  sleep 5
-done
-
-# 2. Run a django migration
-python manage.py migrate --noinput
-
-# 3. Create/Update DukeDS configuration
-python manage.py createddsendpoint "Duke Data Service" $D4S2_DDSCLIENT_URL $D4S2_DDSCLIENT_PORTAL_ROOT $D4S2_DDSCLIENT_AGENT_KEY $D4S2_DDSCLIENT_OPENID_PROVIDER_ID
-
 # 4. Launch gunicorn
 gunicorn -b 0.0.0.0:8000 d4s2.wsgi:application


### PR DESCRIPTION
Removes migration from `run.sh` script so migrations and fixture loading can be handled by ansible.

Updates README with some fixes and a call to run migrate.

Part of the fix for #181
