### PR TITLE
Changes to allow searching all users

### DIFF
--- a/d4s2_api_v2/api.py
+++ b/d4s2_api_v2/api.py
@@ -314,10 +314,10 @@ class DDSAuthProviderViewSet(DDSViewSet):
         serializer = DDSAffiliateSerializer(dds_affiliates, many=True)
         return Response(serializer.data, status=status.HTTP_200_OK)
 
-    @detail_route(methods=['POST'], serializer_class=AddUserSerializer)
-    def add_user(self, request, pk=None):
-        username = request.data.get('username')
+    @detail_route(methods=['POST'], serializer_class=DDSUserSerializer, url_path='get-or-register-user')
+    def get_or_register_user(self, request, pk=None):
+        username = request.data['username']
         dds_util = DDSUtil(request.user)
-        dds_user = self._ds_operation(DDSUser.add_user, dds_util, pk, username)
+        dds_user = self._ds_operation(DDSUser.get_or_register_user, dds_util, pk, username)
         serializer = DDSUserSerializer(instance=dds_user)
         return Response(serializer.data, status=status.HTTP_200_OK)

--- a/d4s2_api_v2/api.py
+++ b/d4s2_api_v2/api.py
@@ -9,7 +9,8 @@ from switchboard.dds_util import DDSUtil, DDSMessageFactory, DDSAuthProvider, DD
 from switchboard.s3_util import S3BucketUtil
 from d4s2_api_v2.serializers import DDSUserSerializer, DDSProjectSerializer, DDSProjectTransferSerializer, \
     UserSerializer, S3EndpointSerializer, S3UserSerializer, S3BucketSerializer, S3DeliverySerializer, \
-    DDSProjectPermissionSerializer, DDSDeliveryPreviewSerializer, DDSAuthProviderSerializer, DDSAffiliateSerializer
+    DDSProjectPermissionSerializer, DDSDeliveryPreviewSerializer, DDSAuthProviderSerializer, DDSAffiliateSerializer, \
+    AddUserSerializer
 from d4s2_api.models import DDSDelivery, S3Endpoint, S3User, S3UserTypes, S3Bucket, S3Delivery
 from d4s2_api_v1.api import AlreadyNotifiedException, get_force_param, build_accept_url, DeliveryViewSet, \
     ModelWithEmailTemplateSetMixin
@@ -311,4 +312,12 @@ class DDSAuthProviderViewSet(DDSViewSet):
         full_name_contains = request.query_params.get('full_name_contains')
         dds_affiliates = self._ds_operation(DDSAffiliate.fetch_list, dds_util, pk, full_name_contains)
         serializer = DDSAffiliateSerializer(dds_affiliates, many=True)
+        return Response(serializer.data, status=status.HTTP_200_OK)
+
+    @detail_route(methods=['POST'], serializer_class=AddUserSerializer)
+    def add_user(self, request, pk=None):
+        username = request.data.get('username')
+        dds_util = DDSUtil(request.user)
+        dds_user = self._ds_operation(DDSUser.add_user, dds_util, pk, username)
+        serializer = DDSUserSerializer(instance=dds_user)
         return Response(serializer.data, status=status.HTTP_200_OK)

--- a/d4s2_api_v2/serializers.py
+++ b/d4s2_api_v2/serializers.py
@@ -149,3 +149,32 @@ class DDSDeliveryPreviewSerializer(serializers.Serializer):
 
     class Meta:
         resource_name = 'delivery-preview'
+
+
+class DDSAuthProviderSerializer(serializers.Serializer):
+    """
+    Serializer for DukeDS auth provider affiliates API
+    """
+    id = serializers.UUIDField()
+    service_id = serializers.UUIDField()
+    name = serializers.CharField()
+    is_deprecated = serializers.BooleanField()
+    is_default = serializers.BooleanField()
+    login_initiation_url = serializers.CharField()
+
+    class Meta:
+        resource_name = 'duke-ds-auth-provider'
+
+
+class DDSAffiliateSerializer(serializers.Serializer):
+    """
+    Serializer for DukeDS auth provider affiliates API
+    """
+    uid = serializers.CharField()
+    full_name = serializers.CharField()
+    first_name = serializers.CharField()
+    last_name = serializers.CharField()
+    email = serializers.CharField()
+
+    class Meta:
+        resource_name = 'duke-ds-affiliates'

--- a/d4s2_api_v2/serializers.py
+++ b/d4s2_api_v2/serializers.py
@@ -178,3 +178,6 @@ class DDSAffiliateSerializer(serializers.Serializer):
 
     class Meta:
         resource_name = 'duke-ds-affiliates'
+
+class AddUserSerializer(serializers.Serializer):
+    username = serializers.CharField()

--- a/d4s2_api_v2/tests_api.py
+++ b/d4s2_api_v2/tests_api.py
@@ -9,6 +9,7 @@ from mock import patch, Mock, MagicMock
 from d4s2_api.models import *
 from mock import call
 from switchboard.s3_util import S3Exception, S3NoSuchBucket
+from switchboard.dds_util import DDSAuthProvider, DDSAffiliate, DDSUser
 
 
 class DDSUsersViewSetTestCase(AuthenticatedResourceTestCase):
@@ -1041,6 +1042,7 @@ class S3DeliveryViewSetTestCase(APITestCase):
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
         self.assertEqual(response.data, [ITEM_EMAIL_TEMPLATES_NOT_SETUP_MSG])
 
+
 class DeliveryPreviewViewTestCase(APITestCase):
 
     def setUp(self):
@@ -1138,3 +1140,100 @@ class DeliveryPreviewViewTestCase(APITestCase):
         response = self.client.post(url, data=data, format='json')
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
         self.assertEqual(response.data, [EMAIL_TEMPLATES_NOT_SETUP_MSG])
+
+
+class DDSAuthProviderViewSetTestCase(AuthenticatedResourceTestCase):
+    def setUp(self):
+        self.user = django_user.objects.create_user(username='user', password='secret')
+        self.client.login(username='user', password='secret')
+        self.provider_dict = {
+            'id': '123',
+            'service_id': '456',
+            'name': 'primary',
+            'is_deprecated': False,
+            'is_default': True,
+            'login_initiation_url': 'someurl'
+        }
+        self.dds_affiliate_dict = {
+            'uid': 'joe123',
+            'full_name': 'Joe Smith',
+            'first_name': 'Joe',
+            'last_name': 'Smith',
+            'email': 'joe@joe.com',
+        }
+        self.dds_user_dict = {
+            'id': '999',
+            'username': 'joe456',
+            'full_name': '',
+            'first_name': '',
+            'last_name': '',
+            'email': '',
+        }
+
+    def test_fails_unauthenticated(self):
+        self.client.logout()
+        url = reverse('v2-dukedsauthprovider-list')
+        response = self.client.post(url, {}, format='json')
+        self.assertUnauthorized(response)
+
+    def test_post_not_permitted(self):
+        url = reverse('v2-dukedsauthprovider-list')
+        data = {}
+        response = self.client.post(url, data, format='json')
+        self.assertEqual(response.status_code, status.HTTP_405_METHOD_NOT_ALLOWED)
+
+    def test_put_not_permitted(self):
+        url = reverse('v2-dukedsauthprovider-list')
+        data = {}
+        response = self.client.put(url, data, format='json')
+        self.assertEqual(response.status_code, status.HTTP_405_METHOD_NOT_ALLOWED)
+
+    @patch('d4s2_api_v2.api.DDSUtil')
+    @patch('d4s2_api_v2.api.DDSAuthProvider')
+    def test_get_provider(self, mock_dds_auth_provider, mock_dds_util):
+        mock_dds_auth_provider.fetch_list.return_value = [DDSAuthProvider(self.provider_dict)]
+        url = reverse('v2-dukedsauthprovider-list')
+        response = self.client.get(url, format='json')
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(response.data), 1)
+
+        provider = response.data[0]
+        self.assertEqual(provider['id'], '123')
+        self.assertEqual(provider['is_deprecated'], False)
+        self.assertEqual(provider['is_default'], True)
+
+    @patch('d4s2_api_v2.api.DDSUtil')
+    @patch('d4s2_api_v2.api.DDSAuthProvider')
+    def test_get_provider(self, mock_dds_auth_provider, mock_dds_util):
+        mock_dds_auth_provider.fetch_one.return_value = DDSAuthProvider(self.provider_dict)
+        url = reverse('v2-dukedsauthprovider-list') + '123/'
+        response = self.client.get(url, format='json')
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+        provider = response.data
+        self.assertEqual(provider['id'], '123')
+        self.assertEqual(provider['is_deprecated'], False)
+        self.assertEqual(provider['is_default'], True)
+        mock_dds_auth_provider.fetch_one.assert_called_with(mock_dds_util.return_value, '123')
+
+    @patch('d4s2_api_v2.api.DDSUtil')
+    @patch('d4s2_api_v2.api.DDSAffiliate')
+    def test_get_affiliates(self, mock_dds_affiliate, mock_dds_util):
+        mock_dds_affiliate.fetch_list.return_value = [DDSAffiliate(self.dds_affiliate_dict)]
+        url = reverse('v2-dukedsauthprovider-list') + '123/affiliates/?full_name_contains=Joe'
+        response = self.client.get(url, format='json')
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(response.data), 1)
+
+        provider = response.data[0]
+        self.assertEqual(provider['uid'], 'joe123')
+        mock_dds_affiliate.fetch_list.assert_called_with(mock_dds_util.return_value, '123', 'Joe')
+
+    @patch('d4s2_api_v2.api.DDSUtil')
+    @patch('d4s2_api_v2.api.DDSUser')
+    def test_get_or_register_user(self, mock_dds_user, mock_dds_util):
+        mock_dds_user.get_or_register_user.return_value = DDSUser(self.dds_user_dict)
+        url = reverse('v2-dukedsauthprovider-list') + '123/get-or-register-user/'
+        response = self.client.post(url, data={'username': 'joe456'}, format='json')
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data['id'], '999')

--- a/d4s2_api_v2/tests_api.py
+++ b/d4s2_api_v2/tests_api.py
@@ -84,7 +84,7 @@ class DDSUsersViewSetTestCase(AuthenticatedResourceTestCase):
         response = self.client.get(url, format='json')
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(len(response.data), 1)
-        mock_dds_util.return_value.get_users.assert_called_with("smith")
+        mock_dds_util.return_value.get_users.assert_called_with("smith", None, None)
 
         user = response.data[0]
         self.assertEqual(user['id'], 'user1')

--- a/d4s2_api_v2/urls.py
+++ b/d4s2_api_v2/urls.py
@@ -5,6 +5,7 @@ from d4s2_api_v2 import api
 router = routers.DefaultRouter()
 router.register(r'deliveries', api.DeliveryViewSet, 'v2-delivery')
 router.register(r'duke-ds-users', api.DDSUsersViewSet, 'v2-dukedsuser')
+router.register(r'duke-ds-auth-providers', api.DDSAuthProviderViewSet, 'v2-dukedsauthprovider')
 router.register(r'duke-ds-projects', api.DDSProjectsViewSet, 'v2-dukedsproject')
 router.register(r'duke-ds-project-transfers', api.DDSProjectTransfersViewSet, 'v2-dukedsprojecttransfer')
 router.register(r'users', api.UserViewSet, 'v2-user')

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,7 @@ django-simple-history==1.8.1
 django-sslserver==0.19
 djangorestframework==3.4.7
 drf-ember-backend==1.1
-DukeDSClient==1.0.5
+DukeDSClient==2.0.1
 enum34==1.1.6
 funcsigs==0.4
 future==0.16.0

--- a/switchboard/dds_util.py
+++ b/switchboard/dds_util.py
@@ -112,6 +112,9 @@ class DDSUtil(object):
     def get_auth_provider_affiliates(self, auth_provider_id, full_name_contains):
         return self.remote_store.data_service.get_auth_provider_affiliates(auth_provider_id, full_name_contains).json()
 
+    def auth_provider_add_user(self, auth_provider_id, username):
+        return self.remote_store.data_service.auth_provider_add_user(auth_provider_id, username).json()
+
 
 class DDSBase(object):
     @classmethod
@@ -140,6 +143,11 @@ class DDSUser(DDSBase):
     @staticmethod
     def fetch_one(dds_util, dds_user_id):
         response = dds_util.get_user(dds_user_id).json()
+        return DDSUser(response)
+
+    @staticmethod
+    def add_user(dds_util, auth_provider_id, username):
+        response = dds_util.auth_provider_add_user(auth_provider_id, username)
         return DDSUser(response)
 
 

--- a/switchboard/dds_util.py
+++ b/switchboard/dds_util.py
@@ -146,9 +146,13 @@ class DDSUser(DDSBase):
         return DDSUser(response)
 
     @staticmethod
-    def add_user(dds_util, auth_provider_id, username):
-        response = dds_util.auth_provider_add_user(auth_provider_id, username)
-        return DDSUser(response)
+    def get_or_register_user(dds_util, auth_provider_id, username):
+        users = dds_util.get_users(username=username)
+        if users:
+            return users[0]
+        else:
+            response = dds_util.auth_provider_add_user(auth_provider_id, username)
+            return DDSUser(response)
 
 
 class DDSProject(DDSBase):
@@ -246,7 +250,6 @@ class DeliveryDetails(object):
         self.ddsutil = DDSUtil(user)
         self.email_template_set = delivery_or_share.email_template_set
         self.user = user
-
 
     def get_from_user(self):
         return DDSUser.fetch_one(self.ddsutil, self.delivery.from_user_id)
@@ -486,8 +489,8 @@ class DDSAuthProvider(DDSBase):
         return DDSAuthProvider.from_list(response['results'])
 
     @staticmethod
-    def fetch_one(dds_util, dds_user_id):
-        response = dds_util.get_auth_provider(dds_user_id)
+    def fetch_one(dds_util, dds_provider_id):
+        response = dds_util.get_auth_provider(dds_provider_id)
         return DDSAuthProvider(response)
 
 

--- a/switchboard/dds_util.py
+++ b/switchboard/dds_util.py
@@ -13,6 +13,7 @@ DDS_SERVICE_NAME = 'Duke Data Service'
 PROJECT_ADMIN_ID = 'project_admin'
 DDS_PERMISSIONS_ID_SEP = '_'
 
+
 class DDSUtil(object):
     def __init__(self, user):
         if not user:
@@ -81,11 +82,8 @@ class DDSUtil(object):
     def share_project_with_user(self, project_id, dds_user_id, auth_role):
         return self.remote_store.data_service.set_user_project_permission(project_id, dds_user_id, auth_role)
 
-    def get_users(self, full_name_contains=None):
-        if full_name_contains:
-            return self.remote_store.data_service.get_users_by_full_name(full_name_contains)
-        else:
-            return self.remote_store.data_service.get_all_users()
+    def get_users(self, full_name_contains=None, email=None, username=None):
+        return self.remote_store.data_service.get_users(full_name_contains, email, username)
 
     def get_user(self, user_id):
         return self.remote_store.data_service.get_user_by_id(user_id)
@@ -104,6 +102,15 @@ class DDSUtil(object):
 
     def get_project_permissions(self, project_id):
         return self.remote_store.data_service.get_project_permissions(project_id).json()
+
+    def get_auth_providers(self):
+        return self.remote_store.data_service.get_auth_providers().json()
+
+    def get_auth_provider(self, auth_provider_id):
+        return self.remote_store.data_service.get_auth_provider(auth_provider_id).json()
+
+    def get_auth_provider_affiliates(self, auth_provider_id, full_name_contains):
+        return self.remote_store.data_service.get_auth_provider_affiliates(auth_provider_id, full_name_contains).json()
 
 
 class DDSBase(object):
@@ -126,8 +133,8 @@ class DDSUser(DDSBase):
         self.email = user_dict.get('email')
 
     @staticmethod
-    def fetch_list(dds_util, full_name_contains):
-        response = dds_util.get_users(full_name_contains).json()
+    def fetch_list(dds_util, full_name_contains, email, username):
+        response = dds_util.get_users(full_name_contains, email, username).json()
         return DDSUser.from_list(response['results'])
 
     @staticmethod
@@ -451,3 +458,48 @@ class DDSMessageFactory(MessageFactory):
         super(DDSMessageFactory, self).__init__(
             DeliveryDetails(delivery, user)
         )
+
+
+class DDSAuthProvider(DDSBase):
+    """
+    A simple object to represent a DDSProject
+    """
+    def __init__(self, provider_dict):
+        self.id = provider_dict.get('id')
+        self.service_id = provider_dict.get('service_id')
+        self.name = provider_dict.get('name')
+        self.is_deprecated = provider_dict.get('is_deprecated')
+        self.is_default = provider_dict.get('is_default')
+        self.login_initiation_url = provider_dict.get('login_initiation_url')
+
+    @staticmethod
+    def fetch_list(dds_util):
+        response = dds_util.get_auth_providers()
+        return DDSAuthProvider.from_list(response['results'])
+
+    @staticmethod
+    def fetch_one(dds_util, dds_user_id):
+        response = dds_util.get_auth_provider(dds_user_id)
+        return DDSAuthProvider(response)
+
+
+class DDSAffiliate(DDSBase):
+    """
+    A simple object to represent a DDSProject
+    """
+    def __init__(self, project_dict):
+        self.uid = project_dict.get('uid')
+        self.full_name = project_dict.get('full_name')
+        self.first_name = project_dict.get('first_name')
+        self.last_name = project_dict.get('last_name')
+        self.email = project_dict.get('email')
+
+    @staticmethod
+    def fetch_list(dds_util, auth_provider_id, full_name_contains):
+        """
+        Fetch list of DDSAffiliates based on auth_provider_id and full_name_contains
+        :param dds_util: DDSUtil
+        :return: [DDSAffiliate]
+        """
+        response = dds_util.get_auth_provider_affiliates(auth_provider_id, full_name_contains)
+        return DDSAffiliate.from_list(response['results'])


### PR DESCRIPTION
Adds `email` and `username` query params for `duke-ds-users` endpoint.
Adds `duke-ds-auth-providers` endpoint for fetching auth providers that has a detail endpoint for searching affiliates for that auth provider.
Endpoints:
- `GET` endpoint allows searching for users not registered `duke-ds-auth-providers/<id>/affiliates/?full_name_contains=<somename>`.
- `POST` endpoint than transforms an affiliate username into a duke-ds-user allows registering a user `duke-ds-auth-providers/<id>/get-or-register-user/`  that has a payload containing `username` and returns a duke-ds-user object.


Requires https://github.com/Duke-GCB/DukeDSClient/pull/210