### PR TITLE
Add missing method to create declined email

### DIFF
--- a/ownership/views.py
+++ b/ownership/views.py
@@ -9,6 +9,7 @@ except ImportError:
 from d4s2_api.models import State
 from switchboard.s3_util import S3Exception, S3DeliveryType, S3NotRecipientException
 from switchboard.dds_util import DDSDeliveryType
+from d4s2_api.utils import MessageDirection
 
 MISSING_TRANSFER_ID_MSG = 'Missing transfer ID.'
 TRANSFER_ID_NOT_FOUND = 'Transfer ID not found.'
@@ -200,7 +201,9 @@ class DeclineView(DeliveryViewBase):
         try:
             delivery_util = self.delivery_type.make_delivery_util(delivery, request.user)
             delivery_util.decline_delivery(reason)
-            message = self.delivery_type.make_processed_message(delivery, request.user, 'declined', 'Reason: {}'.format(reason))
+            message = self.delivery_type.make_processed_message(delivery, request.user, 'declined',
+                                                                MessageDirection.ToSender,
+                                                                'Reason: {}'.format(reason))
             message.send()
             delivery.mark_declined(request.user.get_username(), reason, message.email_text)
         except Exception as e:

--- a/switchboard/dds_util.py
+++ b/switchboard/dds_util.py
@@ -480,6 +480,11 @@ class DDSDeliveryType:
         delivery.mark_accepted(user.get_username(), sender_message.email_text, recipient_message.email_text)
         return warning_message
 
+    @staticmethod
+    def make_processed_message(delivery, user, process_type, direction, warning_message=''):
+        message_factory = DDSMessageFactory(delivery, user)
+        return message_factory.make_processed_message(process_type, direction, warning_message=warning_message)
+
 
 class DDSMessageFactory(MessageFactory):
     def __init__(self, delivery, user):

--- a/switchboard/tests_ddsutil.py
+++ b/switchboard/tests_ddsutil.py
@@ -407,6 +407,19 @@ class DDSDeliveryTypeTestCase(TestCase):
             'second_email_content'
         )
 
+    @patch('switchboard.dds_util.DDSMessageFactory')
+    def test_make_processed_message(self, mock_dds_message_factory):
+        mock_delivery = Mock()
+        mock_user = Mock()
+        message = DDSDeliveryType.make_processed_message(mock_delivery, mock_user, process_type='declined',
+                                                         direction=MessageDirection.ToSender,
+                                                         warning_message='Did not want')
+        self.assertEqual(message, mock_dds_message_factory.return_value.make_processed_message.return_value)
+        mock_dds_message_factory.assert_called_with(mock_delivery, mock_user)
+        mock_dds_message_factory.return_value.make_processed_message.assert_called_with(
+            'declined', MessageDirection.ToSender, warning_message='Did not want'
+        )
+
 
 class DDSProjectTestCase(TestCase):
     def test_constructor(self):


### PR DESCRIPTION
Fixes #196 

Looks like this a bug from https://github.com/Duke-GCB/D4S2/pull/143.
When `DDSDeliveryType` was moved from `ownership/views.py` to `switchboard/dds_util.py` this method was somehow lost. In addition to the missing method we neglected to add the new direction argument to this call. We had unit tests for these items but the mocks were out of date.

Added unit tests and fixed `DDSDeliveryType` adding back in the method and missing argument in decline. Also added an integration test to test out a user declining a delivery.

I tested this running locally and was able to decline a delivery.