### PR TITLE
Support for streamed zip downloads of DukeDS projects

### DIFF
--- a/d4s2/urls.py
+++ b/d4s2/urls.py
@@ -7,6 +7,7 @@ from rest_framework.authtoken import views as authtoken_views
 urlpatterns = [
     url(r'^admin/', admin.site.urls),
     url(r'^ownership/', include('ownership.urls')),
+    url(r'^download/', include('download_service.urls')),
     url(r'^auth/', include('gcb_web_auth.urls')),
     url(r'^api/v1/', include('d4s2_api_v1.urls')),
     url(r'^api/v2/', include('d4s2_api_v2.urls')),

--- a/download_service/apps.py
+++ b/download_service/apps.py
@@ -1,0 +1,5 @@
+from django.apps import AppConfig
+
+
+class DownloadServiceConfig(AppConfig):
+    name = 'download_service'

--- a/download_service/tests_urls.py
+++ b/download_service/tests_urls.py
@@ -1,0 +1,20 @@
+from django.core.urlresolvers import reverse
+from django.test.testcases import TestCase
+from django.urls.exceptions import NoReverseMatch
+
+
+class DownloadUrlTestCase(TestCase):
+    def setUp(self):
+        self.name = 'download-dds-project-zip'
+
+    def test_resolves_uuid_url(self):
+        resolved = reverse(self.name, kwargs={'project_id': '6ee7ff4b-da91-4cff-ab67-4693d701060d'})
+        self.assertEqual(resolved, '/download/dds-projects/6ee7ff4b-da91-4cff-ab67-4693d701060d.zip')
+
+    def test_raises_with_no_params(self):
+        with self.assertRaises(NoReverseMatch):
+            reverse(self.name)
+
+    def test_raises_with_other_params(self):
+        with self.assertRaises(NoReverseMatch):
+            reverse(self.name, kwargs={'file_id': 'some-id'})

--- a/download_service/tests_utils.py
+++ b/download_service/tests_utils.py
@@ -1,0 +1,46 @@
+from django.test.testcases import TestCase
+from download_service.utils import make_client
+from gcb_web_auth.models import DDSUserCredential, DDSEndpoint
+from django.contrib.auth.models import User
+from unittest.mock import patch, call, Mock
+
+
+class MakeClientTestCase(TestCase):
+    def setUp(self):
+        self.user = User.objects.create(username='client_user')
+        self.endpoint = DDSEndpoint.objects.create(
+            name='test',
+            agent_key='agent-key',
+            api_root='http://api.example.org/api/',
+            portal_root='http://www.example.org/',
+            openid_provider_service_id='abc-123',
+            openid_provider_id='def-456',
+            is_default=True
+        )
+
+    @patch('download_service.utils.get_dds_config_for_credentials')
+    @patch('download_service.utils.Client')
+    def test_makes_client_when_from_existing_dds_user_credential(self, mock_client, mock_get_dds_config_for_credentials):
+        credential = DDSUserCredential.objects.create(user=self.user,
+                                                      endpoint=self.endpoint,
+                                                      token='SECRET-TOKEN',
+                                                      dds_id='0000-1234')
+        client = make_client(self.user)
+        self.assertEqual(mock_get_dds_config_for_credentials.call_args, call(credential))
+        self.assertEqual(mock_client.call_args, call(config=mock_get_dds_config_for_credentials.return_value))
+        self.assertEqual(client, mock_client.return_value)
+
+    @patch('download_service.utils.get_dds_token')
+    @patch('download_service.utils.make_auth_config')
+    @patch('download_service.utils.Client')
+    def test_makes_client_from_dds_token_when_no_dds_user_credential(self, mock_client, mock_make_auth_config, mock_get_dds_token):
+        self.assertEqual(DDSUserCredential.objects.count(), 0)
+        mock_key = Mock()
+        mock_get_dds_token.return_value.key = mock_key
+        client = make_client(self.user)
+        self.assertEqual(mock_get_dds_token.call_args, call(self.user))
+        self.assertEqual(mock_make_auth_config.call_args, call(mock_key))
+        self.assertEqual(mock_client.call_args, call(config=mock_make_auth_config.return_value))
+        self.assertEqual(client, mock_client.return_value)
+
+

--- a/download_service/tests_views.py
+++ b/download_service/tests_views.py
@@ -2,7 +2,7 @@ from django.core.urlresolvers import reverse
 from django.test.testcases import TestCase
 from unittest.mock import patch, call
 from django.contrib.auth.models import User
-from download_service.zipbuilder import NotFoundException
+from download_service.zipbuilder import NotFoundException, NotSupportedException
 
 
 @patch('download_service.views.make_client')
@@ -45,3 +45,8 @@ class DDSProjectZipTestCase(TestCase):
         mock_zip_builder.return_value.get_filename.side_effect = NotFoundException('not found')
         response = self.client.get(self.url)
         self.assertEqual(response.status_code, 404)
+
+    def test_error_if_unsupported_verb(self, mock_zip_builder, mock_make_client):
+        mock_zip_builder.return_value.get_filename.side_effect = NotSupportedException('not supported')
+        response = self.client.get(self.url)
+        self.assertEqual(response.status_code, 500)

--- a/download_service/tests_views.py
+++ b/download_service/tests_views.py
@@ -1,0 +1,30 @@
+from django.core.urlresolvers import reverse
+from django.test.testcases import SimpleTestCase
+from unittest.mock import patch, call
+
+
+@patch('download_service.views.make_client')
+@patch('download_service.views.DDSZipBuilder')
+class DDSProjectZipTestCase(SimpleTestCase):
+    def setUp(self):
+        self.project_id = 'abc-123'
+        self.url = reverse('download-dds-project-zip', kwargs={'project_id': self.project_id})
+
+    def test_built_url(self, mock_zip_builder, mock_make_client):
+        self.assertEqual(self.url, '/download/dds-projects/abc-123.zip')
+
+    def test_download_project_builds(self, mock_zip_builder, mock_make_client):
+        response = self.client.get(self.url)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(mock_zip_builder.call_args, call(self.project_id, mock_make_client.return_value))
+
+    def test_response_content(self, mock_zip_builder, mock_make_client):
+        mock_zip_builder.return_value.build.return_value = 'built zip content'
+        response = self.client.get(self.url)
+        self.assertContains(response, 'built zip content')
+
+    def test_response_headers(self, mock_zip_builder, mock_make_client):
+        mock_zip_builder.return_value.get_filename.return_value = 'ABC123.zip'
+        response = self.client.get(self.url)
+        self.assertEqual(response['Content-Type'], 'application/zip')
+        self.assertEqual(response['Content-Disposition'], 'attachment; filename=ABC123.zip')

--- a/download_service/tests_views.py
+++ b/download_service/tests_views.py
@@ -19,9 +19,9 @@ class DDSProjectZipTestCase(SimpleTestCase):
         self.assertEqual(mock_zip_builder.call_args, call(self.project_id, mock_make_client.return_value))
 
     def test_response_content(self, mock_zip_builder, mock_make_client):
-        mock_zip_builder.return_value.build.return_value = 'built zip content'
+        mock_zip_builder.return_value.build_streaming_zipfile.return_value = 'streaming zip content'
         response = self.client.get(self.url)
-        self.assertContains(response, 'built zip content')
+        self.assertContains(response, 'streaming zip content')
 
     def test_response_headers(self, mock_zip_builder, mock_make_client):
         mock_zip_builder.return_value.get_filename.return_value = 'ABC123.zip'

--- a/download_service/tests_views.py
+++ b/download_service/tests_views.py
@@ -2,6 +2,7 @@ from django.core.urlresolvers import reverse
 from django.test.testcases import TestCase
 from unittest.mock import patch, call
 from django.contrib.auth.models import User
+from download_service.zipbuilder import NotFoundException
 
 
 @patch('download_service.views.make_client')
@@ -39,3 +40,8 @@ class DDSProjectZipTestCase(TestCase):
         response = self.client.get(self.url)
         self.assertEqual(response['Content-Type'], 'application/zip')
         self.assertEqual(response['Content-Disposition'], 'attachment; filename=ABC123.zip')
+
+    def test_404_if_project_not_found(self, mock_zip_builder, mock_make_client):
+        mock_zip_builder.return_value.get_filename.side_effect = NotFoundException('not found')
+        response = self.client.get(self.url)
+        self.assertEqual(response.status_code, 404)

--- a/download_service/tests_zipbuilder.py
+++ b/download_service/tests_zipbuilder.py
@@ -1,0 +1,106 @@
+from django.test.testcases import TestCase
+from download_service.zipbuilder import DDSZipBuilder
+from ddsc.sdk.client import Client, File, FileDownload, Project, DDSConnection
+from requests import Response
+from unittest.mock import Mock, patch, create_autospec, PropertyMock, call
+
+
+class DDSZipBuilderTestCase(TestCase):
+
+    @staticmethod
+    def mock_project_with_name(name):
+        mock_project = create_autospec(Project)
+        name_property = PropertyMock(return_value=name)
+        type(mock_project).name = name_property
+        return mock_project
+
+    def setUp(self):
+        self.mock_client = create_autospec(Client)
+        self.mock_client.dds_connection = create_autospec(DDSConnection)
+        self.project_id = '514d0f77-a167-400d-8466-3043428029fe'
+
+    def test_init(self):
+        builder = DDSZipBuilder(self.project_id, self.mock_client)
+        self.assertEqual(builder.project_id, self.project_id)
+        self.assertEqual(builder.client, self.mock_client)
+
+    def test_get_project_name(self):
+        mock_project = DDSZipBuilderTestCase.mock_project_with_name('ProjectABC')
+        self.mock_client.get_project_by_id.return_value = mock_project
+        builder = DDSZipBuilder(self.project_id, self.mock_client)
+        self.assertEqual(builder.get_project_name(), 'ProjectABC')
+
+    def test_get_filename(self):
+        mock_project = DDSZipBuilderTestCase.mock_project_with_name('project-xyz')
+        self.mock_client.get_project_by_id.return_value = mock_project
+        builder = DDSZipBuilder(self.project_id, self.mock_client)
+        self.assertEqual(builder.get_filename(), 'project-xyz.zip')
+
+    @patch('download_service.zipbuilder.PathToFiles')
+    def test_get_dds_paths(self, mock_path_to_files):
+        mock_children = [Mock(), Mock()]
+        self.mock_client.dds_connection.get_project_children.return_value = mock_children
+        builder = DDSZipBuilder(self.project_id, self.mock_client)
+        dds_paths = builder.get_dds_paths()
+        # get_project_children should be called with the project id
+        self.assertEqual(self.mock_client.dds_connection.get_project_children.call_args, call(self.project_id))
+        # PathToFiles().add_paths_for_children_of_node should be called with each child
+        self.assertEqual(mock_path_to_files.return_value.add_paths_for_children_of_node.mock_calls, [
+            call(mock_children[0]),
+            call(mock_children[1])
+        ])
+        self.assertEqual(dds_paths, mock_path_to_files.return_value.paths)
+
+    def test_get_url(self):
+        mock_file_download = create_autospec(FileDownload, host='http://example.org', url='/path/file.ext')
+        mock_get_file_download = self.mock_client.dds_connection.get_file_download
+        mock_get_file_download.return_value = mock_file_download
+        builder = DDSZipBuilder(self.project_id, self.mock_client)
+        mock_file = create_autospec(File)
+        mock_file.id = 'file-id'
+        url = builder.get_url(mock_file)
+        # Get file download should have been called with the file id
+        self.assertEqual(mock_get_file_download.call_args, call('file-id'))
+        # Built URL should be assembled from the properties of the mock_file_download
+        self.assertEqual(url, 'http://example.org/path/file.ext')
+
+    @patch('download_service.zipbuilder.requests.get')
+    @patch('download_service.zipbuilder.DDSZipBuilder.get_url')
+    def test_fetch_chunks(self, mock_get_url, mock_requests_get):
+        mock_chunks = ['chunk1','chunk2','chunk3']
+        url = 'https://example.org/path/file.ext'
+        mock_response = create_autospec(Response)
+        mock_requests_get.return_value = mock_response
+        mock_response.raw = Mock(stream=Mock(return_value=mock_chunks))
+        mock_get_url.return_value = url
+        builder = DDSZipBuilder(self.project_id, self.mock_client)
+        mock_file = create_autospec(File)
+        fetched = builder.fetch(mock_file)
+        self.assertEqual(list(fetched), mock_chunks)
+        # get_url should be called with the file
+        self.assertEqual(mock_get_url.call_args, call(mock_file))
+        # requests_get should be called with the url and stream=True
+        self.assertEqual(mock_requests_get.call_args, call(url, stream=True))
+
+    @patch('download_service.zipbuilder.requests.get')
+    @patch('download_service.zipbuilder.DDSZipBuilder.get_url')
+    def test_fetch_does_not_get_file_url_until_iterated(self, mock_get_url, mock_requests_get):
+        builder = DDSZipBuilder(self.project_id, self.mock_client)
+        # Instantiating a DDSZipBuilder will not fetch any URLs yet
+        self.assertFalse(mock_get_url.called)
+        fetched = builder.fetch(create_autospec(File))
+        # Invoking DDSZipBuilder.fetch() to get a generator must not call get_url
+        self.assertFalse(mock_get_url.called)
+        # Iterating on the generator will trigger the call
+        for _ in fetched:
+            pass
+        self.assertTrue(mock_get_url.called)
+        # Also requests.get should have been called
+        self.assertTrue(mock_requests_get.called)
+
+    def build_streaming_zipfile(self):
+        pass
+
+    def test_call_order(self):
+        pass
+

--- a/download_service/tests_zipbuilder.py
+++ b/download_service/tests_zipbuilder.py
@@ -53,7 +53,7 @@ class DDSZipBuilderTestCase(TestCase):
         self.assertEqual(dds_paths, mock_path_to_files.return_value.paths)
 
     def test_get_url(self):
-        mock_file_download = create_autospec(FileDownload, host='http://example.org', url='/path/file.ext')
+        mock_file_download = create_autospec(FileDownload, host='http://example.org', url='/path/file.ext', http_verb='GET')
         mock_get_file_download = self.mock_client.dds_connection.get_file_download
         mock_get_file_download.return_value = mock_file_download
         builder = DDSZipBuilder(self.project_id, self.mock_client)

--- a/download_service/urls.py
+++ b/download_service/urls.py
@@ -1,0 +1,6 @@
+from django.conf.urls import url
+from download_service import views
+
+urlpatterns = [
+    url(r'^dds-projects/(?P<project_id>.+).zip$', views.dds_project_zip, name='download-dds-project-zip'),
+]

--- a/download_service/utils.py
+++ b/download_service/utils.py
@@ -12,5 +12,5 @@ def make_client(user):
         # May raise an OAuthConfigurationException
         dds_token = get_dds_token(user)
         config = make_auth_config(dds_token.key)
-    client = Client(config=config)  # This assumes it can authenticate
+    client = Client(config=config)
     return client

--- a/download_service/utils.py
+++ b/download_service/utils.py
@@ -1,0 +1,16 @@
+from ddsc.sdk.client import Client
+from gcb_web_auth.models import DDSUserCredential
+from gcb_web_auth.utils import get_dds_config_for_credentials, get_dds_token, make_auth_config
+
+
+def make_client(user):
+    try:
+        dds_credential = DDSUserCredential.objects.get(user=user)
+        config = get_dds_config_for_credentials(dds_credential)
+    except DDSUserCredential.DoesNotExist:
+        # No DDSUserCredential configured for this user, fall back to OAuth
+        # May raise an OAuthConfigurationException
+        dds_token = get_dds_token(user)
+        config = make_auth_config(dds_token.key)
+    client = Client(config=config)  # This assumes it can authenticate
+    return client

--- a/download_service/views.py
+++ b/download_service/views.py
@@ -1,5 +1,5 @@
-from django.http import StreamingHttpResponse
-from download_service.zipbuilder import DDSZipBuilder, NotFoundException
+from django.http import StreamingHttpResponse, HttpResponseServerError
+from download_service.zipbuilder import DDSZipBuilder, NotFoundException, NotSupportedException
 from django.contrib.auth.decorators import login_required
 from download_service.utils import make_client
 from django.http import Http404
@@ -15,4 +15,6 @@ def dds_project_zip(request, project_id):
         response['Content-Disposition'] = 'attachment; filename={}'.format(filename)
         return response
     except NotFoundException as e:
-            raise Http404(e.message)
+        raise Http404(e.message)
+    except NotSupportedException as e:
+        return HttpResponseServerError(content=e.message)

--- a/download_service/views.py
+++ b/download_service/views.py
@@ -1,16 +1,18 @@
 from django.http import StreamingHttpResponse
-from download_service.zipbuilder import DDSZipBuilder
+from download_service.zipbuilder import DDSZipBuilder, NotFoundException
 from django.contrib.auth.decorators import login_required
 from download_service.utils import make_client
+from django.http import Http404
 
 
 @login_required
 def dds_project_zip(request, project_id):
     client = make_client(request.user)
     builder = DDSZipBuilder(project_id, client)
-    # this should trigger an exception if project not found
-    filename = builder.get_filename()
-    # what will this trigger if no access to project
-    response = StreamingHttpResponse(builder.build_streaming_zipfile(), content_type='application/zip')
-    response['Content-Disposition'] = 'attachment; filename={}'.format(filename)
-    return response
+    try:
+        filename = builder.get_filename()
+        response = StreamingHttpResponse(builder.build_streaming_zipfile(), content_type='application/zip')
+        response['Content-Disposition'] = 'attachment; filename={}'.format(filename)
+        return response
+    except NotFoundException as e:
+            raise Http404(e.message)

--- a/download_service/views.py
+++ b/download_service/views.py
@@ -1,0 +1,19 @@
+from django.http import StreamingHttpResponse
+from download_service.zipbuilder import DDSZipBuilder
+from ddsc.sdk.client import Client
+
+
+def make_client():
+    client = Client()  # This assumes it can authenticate
+    return client
+
+
+def dds_project_zip(request, project_id):
+    client = make_client()
+    zip_builder = DDSZipBuilder(project_id, client)
+    # this should trigger an exception if project not found
+    filename = zip_builder.get_filename()
+    # what will this trigger if no access to project
+    response = StreamingHttpResponse(zip_builder.build(), content_type='application/zip')
+    response['Content-Disposition'] = 'attachment; filename={}'.format(filename)
+    return response

--- a/download_service/views.py
+++ b/download_service/views.py
@@ -1,15 +1,12 @@
 from django.http import StreamingHttpResponse
 from download_service.zipbuilder import DDSZipBuilder
-from ddsc.sdk.client import Client
+from django.contrib.auth.decorators import login_required
+from download_service.utils import make_client
 
 
-def make_client():
-    client = Client()  # This assumes it can authenticate
-    return client
-
-
+@login_required
 def dds_project_zip(request, project_id):
-    client = make_client()
+    client = make_client(request.user)
     builder = DDSZipBuilder(project_id, client)
     # this should trigger an exception if project not found
     filename = builder.get_filename()

--- a/download_service/views.py
+++ b/download_service/views.py
@@ -10,10 +10,10 @@ def make_client():
 
 def dds_project_zip(request, project_id):
     client = make_client()
-    zip_builder = DDSZipBuilder(project_id, client)
+    builder = DDSZipBuilder(project_id, client)
     # this should trigger an exception if project not found
-    filename = zip_builder.get_filename()
+    filename = builder.get_filename()
     # what will this trigger if no access to project
-    response = StreamingHttpResponse(zip_builder.build(), content_type='application/zip')
+    response = StreamingHttpResponse(builder.build_streaming_zipfile(), content_type='application/zip')
     response['Content-Disposition'] = 'attachment; filename={}'.format(filename)
     return response

--- a/download_service/zipbuilder.py
+++ b/download_service/zipbuilder.py
@@ -32,6 +32,13 @@ class DDSZipBuilder(object):
         self.project_id = project_id
         self.client = client
 
+    @staticmethod
+    def _handle_dataservice_error(e, message):
+        if e.status_code == 404:
+            raise NotFoundException(message)
+        else:
+            raise
+
     def get_project_name(self):
         """
         Uses the client to look up the project name from DukeDS
@@ -41,10 +48,7 @@ class DDSZipBuilder(object):
             project = self.client.get_project_by_id(self.project_id)
             return project.name
         except DataServiceError as e:
-            if e.status_code == 404:
-                raise NotFoundException('Project {} not found'.format(self.project_id))
-            else:
-                raise
+            DDSZipBuilder._handle_dataservice_error(e, 'Project {} not found'.format(self.project_id))
 
     def get_filename(self):
         """
@@ -66,10 +70,7 @@ class DDSZipBuilder(object):
                 ptf.add_paths_for_children_of_node(child)
             return ptf.paths  # OrderedDict of path -> File
         except DataServiceError as e:
-            if e.status_code == 404:
-                raise NotFoundException('Project {} not found'.format(self.project_id))
-            else:
-                raise
+            DDSZipBuilder._handle_dataservice_error(e, 'Project {} not found'.format(self.project_id))
 
     def get_url(self, dds_file):
         """
@@ -87,10 +88,7 @@ class DDSZipBuilder(object):
             else:
                 raise NotSupportedException('This file requires an unsupported download method: {}'.format(file_download.http_verb))
         except DataServiceError as e:
-            if e.status_code == 404:
-                raise NotFoundException('File with id {} not found'.format(dds_file.id))
-            else:
-                raise
+            DDSZipBuilder._handle_dataservice_error(e, 'File with id {} not found'.format(dds_file.id))
 
     def fetch(self, dds_file):
         """

--- a/download_service/zipbuilder.py
+++ b/download_service/zipbuilder.py
@@ -1,0 +1,107 @@
+from zipstream import ZipFile
+from ddsc.sdk.client import PathToFiles
+import requests
+
+
+class DDSZipBuilder(object):
+    """
+    Builds a zip file as a stream, containing all the files in a DukeDS project.
+    Notes about generators and timeliness
+    """
+
+    def __init__(self, project_id, client):
+        """
+
+        :param project_id: The id of a DukeDS project
+        :param client: A ddsc.sdk.Client instance ready to make API calls
+        """
+        self.project_id = project_id
+        self.client = client
+
+    def get_project_name(self):
+        """
+        Uses the client to look up the project name from DukeDS
+        :return: str: project name
+        """
+        project = self.client.get_project_by_id(self.project_id)
+        return project.name
+
+    def get_filename(self):
+        """
+        Generates a file name for the zip file based on the project name
+        :return: str: file name ending in .zip
+        """
+        project_name = self.get_project_name()
+        return '{}.zip'.format(project_name)
+
+    def get_dds_paths(self):
+        """
+        Builds a mapping of file paths (strings) in the dds project to ddsc.sdk.client.File objects
+        :return: OrderedDict where keys are relative paths in the project and values are ddsc.sdk.client.File objects
+        """
+        children = self.client.dds_connection.get_project_children(self.project_id)
+        ptf = PathToFiles()
+        for child in children:
+            ptf.add_paths_for_children_of_node(child)
+        return ptf.paths  # OrderedDict of path -> File
+
+    def get_url(self, dds_file):
+        """
+        Uses the client to get a download URL for a ddsc.sdk.client.File object. This URL will be signed with an
+        expiration date, so this method should only be called right before the URL will be fetched.
+
+        :param dds_file: A ddsc.sdk.client.File object for which to get a URL
+        :return: The URL string to GET.
+        """
+        # This is a time-sensitive call, so we should only do it right before fetch
+        file_download = self.client.dds_connection.get_file_download(dds_file.id)
+        return '{}{}'.format(file_download.host, file_download.url)
+
+    def fetch(self, dds_file):
+        """
+        Generator to provide the contents of the DDS file using requests.get with a streaming response.
+
+        Note: Since self.get_url() returns a URL that will expire, it's critical that the yield and the get_url()
+        call appear in the same function. The 'yield' in this function actually causes the get_url() call to be deferred
+        until the first time the generator is consumed. If the yield were in a nested function, get_url() would be
+        called immediately and the URL could easily expire before it's fetched.
+
+        :param dds_file: A ddsc.sdk.client.File object to fetch
+        :return: generator, bytes of the DDS file fetched from its URL.
+        """
+        # Due to the specifics of how python generators work, we have to make sure the yield appears in the same
+        # function as the call to self.get_url().
+        url = self.get_url(dds_file)
+        response = requests.get(url, stream=True)
+        for chunk in response.raw.stream():
+            yield chunk
+
+    def make_streaming_zipfile(self):
+        """
+        Make a generator that, when consumed, fetches DDS file contents on demand using zipstream.ZipFile's
+        write_iter method.
+        :return: a zipstream.ZipFile with the contents
+        """
+        # Set allowZip64 explicitly - it normally looks at file size but since we're building on the fly
+        # we don't know that ahead of time
+        zipfile = ZipFile(allowZip64=True)
+        paths = self.get_dds_paths()
+        for (filename, dds_file) in paths.items():
+            # Must provide buffer_size so that write_iter will know to use zip64
+            file_size = dds_file.current_version['upload']['size']
+            zipfile.write_iter(filename, self.fetch(dds_file), buffer_size=file_size)
+        return zipfile
+
+    def build(self):
+        """
+        Makes a generator that iterates over the zipfile?
+        Not sure we need this additional layer actually
+        :return:
+        """
+        def generate():
+            generator = self.make_streaming_zipfile()
+            for chunk in generator:
+                yield chunk
+
+        return generate()
+

--- a/download_service/zipbuilder.py
+++ b/download_service/zipbuilder.py
@@ -64,10 +64,9 @@ class DDSZipBuilder(object):
         :return: OrderedDict where keys are relative paths in the project and values are ddsc.sdk.client.File objects
         """
         try:
-            children = self.client.dds_connection.get_project_children(self.project_id)
+            project = self.client.get_project_by_id(self.project_id)
             ptf = PathToFiles()
-            for child in children:
-                ptf.add_paths_for_children_of_node(child)
+            ptf.add_paths_for_children_of_node(project)
             return ptf.paths  # OrderedDict of path -> File
         except DataServiceError as e:
             DDSZipBuilder._handle_dataservice_error(e, 'Project {} not found'.format(self.project_id))

--- a/download_service/zipbuilder.py
+++ b/download_service/zipbuilder.py
@@ -124,5 +124,3 @@ class DDSZipBuilder(object):
             file_size = dds_file.current_version['upload']['size']
             zipfile.write_iter(filename, self.fetch(dds_file), buffer_size=file_size)
         return zipfile
-
-

--- a/download_service/zipbuilder.py
+++ b/download_service/zipbuilder.py
@@ -76,7 +76,7 @@ class DDSZipBuilder(object):
         for chunk in response.raw.stream():
             yield chunk
 
-    def make_streaming_zipfile(self):
+    def build_streaming_zipfile(self):
         """
         Make a generator that, when consumed, fetches DDS file contents on demand using zipstream.ZipFile's
         write_iter method.
@@ -92,16 +92,4 @@ class DDSZipBuilder(object):
             zipfile.write_iter(filename, self.fetch(dds_file), buffer_size=file_size)
         return zipfile
 
-    def build(self):
-        """
-        Makes a generator that iterates over the zipfile?
-        Not sure we need this additional layer actually
-        :return:
-        """
-        def generate():
-            generator = self.make_streaming_zipfile()
-            for chunk in generator:
-                yield chunk
-
-        return generate()
 

--- a/download_service/zipbuilder.py
+++ b/download_service/zipbuilder.py
@@ -20,12 +20,10 @@ class NotSupportedException(ZipBuilderException):
 class DDSZipBuilder(object):
     """
     Builds a zip file as a stream, containing all the files in a DukeDS project.
-    Notes about generators and timeliness
     """
 
     def __init__(self, project_id, client):
         """
-
         :param project_id: The id of a DukeDS project
         :param client: A ddsc.sdk.Client instance ready to make API calls
         """

--- a/requirements.txt
+++ b/requirements.txt
@@ -39,3 +39,4 @@ six==1.10.0
 traitlets==4.3.1
 wcwidth==0.1.7
 whitenoise==3.3.1
+zipstream-new==1.1.5


### PR DESCRIPTION
- Adds a `download_service` app, designed to provide simpler downloads to users. 
- GET `/download/dds-projects/<project-id>.zip` will respond with a streamed zip file download of every file in a Duke DS project, provided the user is authenticated and has download access to the project.
- Core functionality is in the DDSZipBuilder class. It uses the `zipstream-new` package to provide a streaming zip file with minimal CPU/memory/disk usage by the server. It is generator-driven, so that data is only fetched as needed. Unique requirements are documented in comments and in tests_zipbuilder.py (e.g. file paths and sizes are determined early, but signed content URLs with an expiration date not requested until they are needed)
- Since the size of the streaming zip file is not known ahead of time, the HTTP response does not include a content length. When we implement links to this endpoint, we should provide an estimated file size.

Fixes #203