### PR TITLE
Improvements for downloading DDS projects as zip files

### DIFF
--- a/d4s2_api_v2/api.py
+++ b/d4s2_api_v2/api.py
@@ -29,7 +29,7 @@ class WrappedDataServiceException(APIException):
     """
     def __init__(self, data_service_error):
         self.status_code = data_service_error.status_code
-        self.detail = data_service_error.response
+        self.detail = str(data_service_error)
 
 
 class BadRequestException(APIException):

--- a/d4s2_api_v2/api.py
+++ b/d4s2_api_v2/api.py
@@ -4,13 +4,13 @@ from rest_framework.decorators import list_route, detail_route
 from rest_framework.response import Response
 from django.db.models import Q
 from django_filters.rest_framework import DjangoFilterBackend
-from switchboard.dds_util import DDSUser, DDSProject, DDSProjectTransfer, DDSProjectPermissions
+from switchboard.dds_util import DDSUser, DDSProject, DDSProjectTransfer, DDSProjectPermissions, DDSProjectSummary
 from switchboard.dds_util import DDSUtil, DDSMessageFactory, DDSAuthProvider, DDSAffiliate
 from switchboard.s3_util import S3BucketUtil
 from d4s2_api_v2.serializers import DDSUserSerializer, DDSProjectSerializer, DDSProjectTransferSerializer, \
     UserSerializer, S3EndpointSerializer, S3UserSerializer, S3BucketSerializer, S3DeliverySerializer, \
     DDSProjectPermissionSerializer, DDSDeliveryPreviewSerializer, DDSAuthProviderSerializer, DDSAffiliateSerializer, \
-    AddUserSerializer
+    AddUserSerializer, DDSProjectSummarySerializer
 from d4s2_api.models import DDSDelivery, S3Endpoint, S3User, S3UserTypes, S3Bucket, S3Delivery
 from d4s2_api_v1.api import AlreadyNotifiedException, get_force_param, build_accept_url, DeliveryViewSet, \
     ModelWithEmailTemplateSetMixin
@@ -153,6 +153,14 @@ class DDSProjectsViewSet(DDSViewSet):
         user_id = request.query_params.get('user')
         project_permissions = self._ds_operation(DDSProjectPermissions.fetch_list, dds_util, pk, user_id)
         serializer = DDSProjectPermissionSerializer(project_permissions, many=True)
+        return Response(serializer.data, status=status.HTTP_200_OK)
+
+    @detail_route(methods=['get'], url_path='summary', serializer_class=DDSProjectSummarySerializer)
+    def summary(self, request, pk=None):
+        dds_project_id = pk
+        dds_util = DDSUtil(request.user)
+        project_summary = DDSProjectSummary.fetch_one(dds_util, dds_project_id)
+        serializer = DDSProjectSummarySerializer(project_summary)
         return Response(serializer.data, status=status.HTTP_200_OK)
 
 

--- a/d4s2_api_v2/serializers.py
+++ b/d4s2_api_v2/serializers.py
@@ -33,6 +33,15 @@ class DDSProjectSerializer(serializers.Serializer):
         resource_name = 'duke-ds-projects'
 
 
+class DDSProjectSummarySerializer(DDSProjectSerializer):
+    total_size = serializers.IntegerField()
+    file_count = serializers.IntegerField()
+    folder_count = serializers.IntegerField()
+
+    class Meta:
+        resource_name = 'duke-ds-project-summaries'
+
+
 class DDSProjectTransferSerializer(serializers.Serializer):
     id = serializers.UUIDField()
     status = serializers.CharField()

--- a/d4s2_api_v2/serializers.py
+++ b/d4s2_api_v2/serializers.py
@@ -28,6 +28,7 @@ class DDSProjectSerializer(serializers.Serializer):
     name = serializers.CharField()
     description = serializers.CharField()
     is_deleted = serializers.BooleanField()
+    url = serializers.URLField()
 
     class Meta:
         resource_name = 'duke-ds-projects'

--- a/d4s2_api_v2/tests_api.py
+++ b/d4s2_api_v2/tests_api.py
@@ -235,7 +235,8 @@ class DDSProjectsViewSetTestCase(AuthenticatedResourceTestCase):
         self.assertEqual(response.status_code, status.HTTP_405_METHOD_NOT_ALLOWED)
 
     @patch('d4s2_api_v2.api.DDSUtil')
-    def test_list_projects(self, mock_dds_util):
+    @patch('d4s2_api_v2.api.DDSUtil.get_project_url')
+    def test_list_projects(self, mock_get_project_url, mock_dds_util):
         mock_response = Mock()
         mock_response.json.return_value = {
             'results': [
@@ -271,7 +272,8 @@ class DDSProjectsViewSetTestCase(AuthenticatedResourceTestCase):
         self.assertEqual(project['is_deleted'], False)
 
     @patch('d4s2_api_v2.api.DDSUtil')
-    def test_get_project(self, mock_dds_util):
+    @patch('d4s2_api_v2.api.DDSUtil.get_project_url')
+    def test_get_project(self, mock_get_project_url, mock_dds_util):
         mock_response = Mock()
         mock_response.json.return_value = {
             'id': 'project1',
@@ -354,7 +356,8 @@ class DDSProjectsViewSetTestCase(AuthenticatedResourceTestCase):
         self.assertEqual(permission['auth_role'], 'file_downloader')
 
     @patch('d4s2_api_v2.api.DDSUtil')
-    def test_get_summary(self, mock_dds_util):
+    @patch('d4s2_api_v2.api.DDSUtil.get_project_url')
+    def test_get_summary(self, mock_get_project_url, mock_dds_util):
         mock_project_response = Mock()
         mock_project_response.json.return_value = {
             'id': 'project1',
@@ -410,7 +413,8 @@ class DDSProjectTransfersViewSetTestCase(AuthenticatedResourceTestCase):
         self.assertEqual(response.status_code, status.HTTP_405_METHOD_NOT_ALLOWED)
 
     @patch('d4s2_api_v2.api.DDSUtil')
-    def test_list_transfers(self, mock_dds_util):
+    @patch('d4s2_api_v2.api.DDSUtil.get_project_url')
+    def test_list_transfers(self, mock_get_project_url, mock_dds_util):
         mock_response = Mock()
         email_template_set = EmailTemplateSet.objects.create(name='someset')
         delivery = DDSDelivery.objects.create(project_id='project1', from_user_id='user1', to_user_id='user2',
@@ -487,7 +491,8 @@ class DDSProjectTransfersViewSetTestCase(AuthenticatedResourceTestCase):
         self.assertEqual(transfer['delivery'], None)
 
     @patch('d4s2_api_v2.api.DDSUtil')
-    def test_get_project(self, mock_dds_util):
+    @patch('d4s2_api_v2.api.DDSUtil.get_project_url')
+    def test_get_project(self, mock_get_project_url, mock_dds_util):
         mock_response = Mock()
         mock_response.json.return_value = {
             'id': 'transfer1',

--- a/download_service/tests_urls.py
+++ b/download_service/tests_urls.py
@@ -7,9 +7,9 @@ class DownloadUrlTestCase(TestCase):
     def setUp(self):
         self.name = 'download-dds-project-zip'
 
-    def test_resolves_uuid_url(self):
-        resolved = reverse(self.name, kwargs={'project_id': '6ee7ff4b-da91-4cff-ab67-4693d701060d'})
-        self.assertEqual(resolved, '/download/dds-projects/6ee7ff4b-da91-4cff-ab67-4693d701060d.zip')
+    def test_resolves_download_url(self):
+        resolved = reverse(self.name, kwargs={'project_id': '6ee7ff4b-da91-4cff-ab67-4693d701060d', 'filename': 'ProjectABC.zip'})
+        self.assertEqual(resolved, '/download/dds-projects/6ee7ff4b-da91-4cff-ab67-4693d701060d/ProjectABC.zip')
 
     def test_raises_with_no_params(self):
         with self.assertRaises(NoReverseMatch):

--- a/download_service/tests_zipbuilder.py
+++ b/download_service/tests_zipbuilder.py
@@ -226,3 +226,14 @@ class DDSZipBuilderExceptionsTestCase(TestCase):
         self.mock_client.dds_connection.get_file_download.side_effect = MockDataServiceError(500)
         with self.assertRaises(DataServiceError):
             self.builder.get_url(self.mock_dds_file)
+
+    @patch('download_service.zipbuilder.DDSZipBuilder.get_filename')
+    def test_raise_on_filename_mismatch_raises(self, mock_get_filename):
+        mock_get_filename.return_value = 'file1.zip'
+        with self.assertRaisesMessage(NotFoundException, 'Project abc not found'):
+            self.builder.raise_on_filename_mismatch('file2.zip')
+
+    @patch('download_service.zipbuilder.DDSZipBuilder.get_filename')
+    def test_raise_on_filename_mismatch_ok(self, mock_get_filename):
+        mock_get_filename.return_value = 'file1.zip'
+        self.builder.raise_on_filename_mismatch('file1.zip')

--- a/download_service/urls.py
+++ b/download_service/urls.py
@@ -2,5 +2,5 @@ from django.conf.urls import url
 from download_service import views
 
 urlpatterns = [
-    url(r'^dds-projects/(?P<project_id>.+).zip$', views.dds_project_zip, name='download-dds-project-zip'),
+    url(r'^dds-projects/(?P<project_id>.+)/(?P<filename>.+\.zip)$', views.dds_project_zip, name='download-dds-project-zip'),
 ]

--- a/download_service/views.py
+++ b/download_service/views.py
@@ -6,11 +6,11 @@ from django.http import Http404
 
 
 @login_required
-def dds_project_zip(request, project_id):
+def dds_project_zip(request, project_id, filename):
     client = make_client(request.user)
     builder = DDSZipBuilder(project_id, client)
     try:
-        filename = builder.get_filename()
+        builder.raise_on_filename_mismatch(filename)
         response = StreamingHttpResponse(builder.build_streaming_zipfile(), content_type='application/zip')
         response['Content-Disposition'] = 'attachment; filename={}'.format(filename)
         return response

--- a/download_service/zipbuilder.py
+++ b/download_service/zipbuilder.py
@@ -56,6 +56,17 @@ class DDSZipBuilder(object):
         project_name = self.get_project_name()
         return '{}.zip'.format(project_name)
 
+    def raise_on_filename_mismatch(self, filename):
+        """
+        Raises a NotFoundException if the supplied filename does not match this builder's
+        generated filename (should be project_name + '.zip'
+
+        :param filename: str: The file name to compare
+        """
+        expected_filename = self.get_filename()
+        if filename != expected_filename:
+            raise NotFoundException('Project {} not found'.format(self.project_id))
+
     def get_dds_paths(self):
         """
         Builds a mapping of file paths (strings) in the dds project to ddsc.sdk.client.File objects

--- a/switchboard/dds_util.py
+++ b/switchboard/dds_util.py
@@ -47,7 +47,8 @@ class DDSUtil(object):
         project = self.get_remote_project(project_id)
         return self.remote_store.fetch_remote_project(project.name, must_exist=True)
 
-    def get_project_url(self, project_id):
+    @staticmethod
+    def get_project_url(project_id):
         endpoint = get_default_dds_endpoint()
         return '{}/#/project/{}'.format(endpoint.portal_root, project_id)
 
@@ -181,6 +182,8 @@ class DDSProject(DDSBase):
         self.name = project_dict.get('name')
         self.description = project_dict.get('description')
         self.is_deleted = project_dict.get('is_deleted')
+        # URL is useful for all DDSProject instances not provided by DDS API
+        self.url = DDSUtil.get_project_url(self.id)
 
     @staticmethod
     def fetch_list(dds_util):
@@ -328,7 +331,7 @@ class DeliveryDetails(object):
             return DDSProject.fetch_one(self.ddsutil, self.delivery.project_id)
 
     def get_project_url(self):
-        return self.ddsutil.get_project_url(self.delivery.project_id)
+        return DDSUtil.get_project_url(self.delivery.project_id)
 
     def get_user_message(self):
         return self.delivery.user_message

--- a/switchboard/dds_util.py
+++ b/switchboard/dds_util.py
@@ -47,7 +47,6 @@ class DDSUtil(object):
         project = self.get_remote_project(project_id)
         return self.remote_store.fetch_remote_project(project.name, must_exist=True)
 
-
     def get_project_url(self, project_id):
         endpoint = get_default_dds_endpoint()
         return '{}/#/project/{}'.format(endpoint.portal_root, project_id)
@@ -94,6 +93,9 @@ class DDSUtil(object):
 
     def get_project(self, project_id):
         return self.remote_store.data_service.get_project_by_id(project_id)
+
+    def get_project_children(self, project_id):
+        return self.remote_store.data_service.get_project_children(project_id, '')
 
     def get_current_user(self):
         return self.remote_store.get_current_user()
@@ -194,6 +196,39 @@ class DDSProject(DDSBase):
     def fetch_one(dds_util, dds_project_id):
         response = dds_util.get_project(dds_project_id).json()
         return DDSProject(response)
+
+
+class DDSProjectSummary(DDSProject):
+
+    def __init__(self, project_dict):
+        super().__init__(project_dict)
+        self.children = project_dict.get('children', [])
+
+    @staticmethod
+    def fetch_one(dds_util, dds_project_id):
+        project_dict = dds_util.get_project(dds_project_id).json()
+        children = dds_util.get_project_children(dds_project_id).json()
+        project_dict['children'] = children['results']
+        return DDSProjectSummary(project_dict)
+
+    def _get_children_of_kind(self, kind):
+        return [child for child in self.children if child['kind'] == kind]
+
+    def _get_files(self):
+        return self._get_children_of_kind('dds-file')
+
+    def _get_folders(self):
+        return self._get_children_of_kind('dds-folder')
+
+    def total_size(self):
+        sizes = [file['current_version']['upload']['size'] for file in self._get_files()]
+        return sum(sizes)
+
+    def file_count(self):
+        return len(self._get_files())
+
+    def folder_count(self):
+        return len(self._get_folders())
 
 
 class DDSProjectPermissions(DDSBase):

--- a/switchboard/tests_ddsutil.py
+++ b/switchboard/tests_ddsutil.py
@@ -211,7 +211,7 @@ class TestDeliveryDetails(TestCase):
             Mock(full_name='joe', email='joe@joe.com'),
             Mock(full_name='bob', email='bob@bob.com'),
         ]
-        mock_dds_util.return_value.get_project_url.return_value = 'projecturl'
+        mock_dds_util.get_project_url.return_value = 'projecturl'
         delivery = Mock(user_message='user message text')
         user = Mock()
         details = DeliveryDetails(delivery, user)
@@ -240,7 +240,7 @@ class TestDeliveryDetails(TestCase):
             Mock(full_name='joe', email='joe@joe.com'),
             Mock(full_name='bob', email='bob@bob.com'),
         ]
-        mock_dds_util.return_value.get_project_url.return_value = 'projecturl'
+        mock_dds_util.get_project_url.return_value = 'projecturl'
         delivery = Mock(user_message='user message text', transfer_id='123')
         user = Mock()
         details = DeliveryDetails(delivery, user)
@@ -432,8 +432,10 @@ class DDSDeliveryTypeTestCase(TestCase):
         )
 
 
+@patch('switchboard.dds_util.DDSUtil.get_project_url')
 class DDSProjectTestCase(TestCase):
-    def test_constructor(self):
+    def test_constructor(self, mock_get_project_url):
+        mock_get_project_url.return_value = 'http://example.org'
         project = DDSProject({
             'id': '123',
             'name': 'mouse',
@@ -444,8 +446,10 @@ class DDSProjectTestCase(TestCase):
         self.assertEqual(project.name, 'mouse')
         self.assertEqual(project.description, 'mouse rna analysis')
         self.assertEqual(project.is_deleted, False)
+        self.assertEqual(project.url, 'http://example.org')
 
-    def test_fetch_list(self):
+    def test_fetch_list(self, mock_get_project_url):
+        mock_get_project_url.return_value = 'http://example.org'
         mock_dds_util = Mock()
         mock_dds_util.get_projects.return_value.json.return_value = {
             'results': [
@@ -463,8 +467,10 @@ class DDSProjectTestCase(TestCase):
         self.assertEqual(projects[0].name, 'mouse')
         self.assertEqual(projects[0].description, 'mouse RNA')
         self.assertEqual(projects[0].is_deleted, False)
+        self.assertEqual(projects[0].url, 'http://example.org')
 
 
+@patch('switchboard.dds_util.DDSUtil.get_project_url')
 class DDSProjectSummaryTestCase(TestCase):
 
     def setUp(self):
@@ -477,12 +483,12 @@ class DDSProjectSummaryTestCase(TestCase):
             {'id': 'fo2', 'kind': 'dds-folder'}
         ]
 
-    def test_constructor(self):
+    def test_constructor(self, mock_get_project_url):
         project_summary = DDSProjectSummary({'id': '123', 'children': self.children})
         self.assertEqual(project_summary.id, '123')
         self.assertEqual(project_summary.children, self.children)
 
-    def test_fetch_one(self):
+    def test_fetch_one(self, mock_get_project_url):
         mock_dds_util = Mock()
         mock_dds_util.get_project.return_value.json.return_value = self.project
         mock_dds_util.get_project_children.return_value.json.return_value = {'results': self.children}
@@ -490,15 +496,15 @@ class DDSProjectSummaryTestCase(TestCase):
         self.assertEqual(project_summary.id, '123')
         self.assertEqual(project_summary.children, self.children)
 
-    def test_total_size(self):
+    def test_total_size(self, mock_get_project_url):
         project_summary = DDSProjectSummary({'id': '123', 'children': self.children})
         self.assertEqual(project_summary.total_size(), 600)
 
-    def test_file_count(self):
+    def test_file_count(self, mock_get_project_url):
         project_summary = DDSProjectSummary({'id': '123', 'children': self.children})
         self.assertEqual(project_summary.file_count(), 3)
 
-    def test_folder_count(self):
+    def test_folder_count(self, mock_get_project_url):
         project_summary = DDSProjectSummary({'id': '123', 'children': self.children})
         self.assertEqual(project_summary.folder_count(), 2)
 


### PR DESCRIPTION
- Reworks url scheme to require the expected filename (see 7fd1cdda5dbef04c915efbcaed2c5820a4eea9ac)
- Adds a detail route `GET /api/v2/duke-ds-projects/:id/summary/` that provides project summary details such as total size and count of files/folders
- Adds `DDSProjectSummarySerializer` to contain summary details
- Adds`DDSProjectSummary` to fetch children and build these summaries
