### PR TITLE
Fix errors fetching project summaries

### DIFF
--- a/switchboard/dds_util.py
+++ b/switchboard/dds_util.py
@@ -204,7 +204,7 @@ class DDSProject(DDSBase):
 class DDSProjectSummary(DDSProject):
 
     def __init__(self, project_dict):
-        super().__init__(project_dict)
+        super(DDSProject, self).__init__(project_dict)
         self.children = project_dict.get('children', [])
 
     @staticmethod

--- a/switchboard/dds_util.py
+++ b/switchboard/dds_util.py
@@ -204,7 +204,7 @@ class DDSProject(DDSBase):
 class DDSProjectSummary(DDSProject):
 
     def __init__(self, project_dict):
-        super(DDSProject, self).__init__(project_dict)
+        super(DDSProjectSummary, self).__init__(project_dict)
         self.children = project_dict.get('children', [])
 
     @staticmethod


### PR DESCRIPTION
Original logic was written for Python 3 but not compatible with Python 2. Created #208 to request upgrade.
After fixing this and deploying to dev, downloads are working too.

Fixes #207