### PR TITLE
Fixes for download timeouts

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -17,6 +17,8 @@ enum34==1.1.6
 funcsigs==0.4
 future==0.16.0
 gcb-web-auth==1.1.1
+gevent==1.4.0
+greenlet==0.4.15
 gunicorn==19.7.1
 ipython==5.1.0
 ipython-genutils==0.1.0

--- a/run.sh
+++ b/run.sh
@@ -22,4 +22,6 @@ python manage.py migrate --noinput
 python manage.py createddsendpoint "Duke Data Service" $D4S2_DDSCLIENT_URL $D4S2_DDSCLIENT_PORTAL_ROOT $D4S2_DDSCLIENT_AGENT_KEY $D4S2_DDSCLIENT_OPENID_PROVIDER_SERVICE_ID $D4S2_DDSCLIENT_OPENID_PROVIDER_ID
 
 # 4. Launch gunicorn
-gunicorn -b 0.0.0.0:8000 d4s2.wsgi:application
+# gevent workers are async and needed to service streaming downloads
+# with the default (sync) workers, streaming download responses time out.
+gunicorn -b 0.0.0.0:8000 --worker-class gevent d4s2.wsgi:application

--- a/run.sh
+++ b/run.sh
@@ -24,4 +24,4 @@ python manage.py createddsendpoint "Duke Data Service" $D4S2_DDSCLIENT_URL $D4S2
 # 4. Launch gunicorn
 # gevent workers are async and needed to service streaming downloads
 # with the default (sync) workers, streaming download responses time out.
-gunicorn -b 0.0.0.0:8000 --worker-class gevent d4s2.wsgi:application
+gunicorn -b 0.0.0.0:8000 d4s2.wsgi:application

--- a/run.sh
+++ b/run.sh
@@ -22,4 +22,4 @@ python manage.py migrate --noinput
 python manage.py createddsendpoint "Duke Data Service" $D4S2_DDSCLIENT_URL $D4S2_DDSCLIENT_PORTAL_ROOT $D4S2_DDSCLIENT_AGENT_KEY $D4S2_DDSCLIENT_OPENID_PROVIDER_SERVICE_ID $D4S2_DDSCLIENT_OPENID_PROVIDER_ID
 
 # 4. Launch gunicorn
-gunicorn -b 0.0.0.0:8000 d4s2.wsgi:application
+gunicorn -b 0.0.0.0:8000 --timeout 120 d4s2.wsgi:application

--- a/run.sh
+++ b/run.sh
@@ -22,4 +22,4 @@ python manage.py migrate --noinput
 python manage.py createddsendpoint "Duke Data Service" $D4S2_DDSCLIENT_URL $D4S2_DDSCLIENT_PORTAL_ROOT $D4S2_DDSCLIENT_AGENT_KEY $D4S2_DDSCLIENT_OPENID_PROVIDER_SERVICE_ID $D4S2_DDSCLIENT_OPENID_PROVIDER_ID
 
 # 4. Launch gunicorn
-gunicorn -b 0.0.0.0:8000 --timeout 120 d4s2.wsgi:application
+gunicorn -b 0.0.0.0:8000 d4s2.wsgi:application


### PR DESCRIPTION
Installs gevent for gunicorn to use async workers. Activate gevent workers by setting `GUNICORN_CMD_ARGS="--worker-class gevent"`

fixes #212 