### PR TITLE
Adds root_folder_count to DDSProjectSummary

### DIFF
--- a/d4s2_api_v2/serializers.py
+++ b/d4s2_api_v2/serializers.py
@@ -40,6 +40,7 @@ class DDSProjectSummarySerializer(DDSProjectSerializer):
     total_size = serializers.IntegerField()
     file_count = serializers.IntegerField()
     folder_count = serializers.IntegerField()
+    root_folder_count = serializers.IntegerField()
 
     class Meta:
         resource_name = 'duke-ds-project-summaries'

--- a/d4s2_api_v2/tests_api.py
+++ b/d4s2_api_v2/tests_api.py
@@ -383,11 +383,11 @@ class DDSProjectsViewSetTestCase(AuthenticatedResourceTestCase):
         mock_children_response = Mock()
         mock_children_response.json.return_value = {
             'results': [
-                {'id': 'fo1', 'kind': 'dds-folder' },
+                {'id': 'fo1', 'kind': 'dds-folder', 'parent': { 'kind': 'dds-project'}},
                 {'id': 'fi1', 'kind': 'dds-file', 'current_version': {'upload': {'size': 100}}},
                 {'id': 'fi2', 'kind': 'dds-file', 'current_version': {'upload': {'size': 200}}},
                 {'id': 'fi3', 'kind': 'dds-file', 'current_version': {'upload': {'size': 300}}},
-                {'id': 'fo2', 'kind': 'dds-folder' },
+                {'id': 'fo2', 'kind': 'dds-folder', 'parent': { 'kind': 'dds-folder'}},
             ]
         }
         mock_dds_util.return_value.get_project.return_value = mock_project_response
@@ -399,6 +399,7 @@ class DDSProjectsViewSetTestCase(AuthenticatedResourceTestCase):
         self.assertEqual(summary['id'], 'project1')
         self.assertEqual(summary['file_count'], 3)
         self.assertEqual(summary['folder_count'], 2)
+        self.assertEqual(summary['root_folder_count'], 1)
         self.assertEqual(summary['total_size'], 600)
         self.assertEqual(mock_dds_util.return_value.get_project.call_args, call('project1'))
         self.assertEqual(mock_dds_util.return_value.get_project_children.call_args, call('project1'))

--- a/switchboard/dds_util.py
+++ b/switchboard/dds_util.py
@@ -225,6 +225,9 @@ class DDSProjectSummary(DDSProject):
     def _get_folders(self):
         return self._get_children_of_kind('dds-folder')
 
+    def get_root_folders(self):
+        return [folder for folder in self._get_folders() if folder['parent']['kind'] == 'dds-project']
+
     def total_size(self):
         sizes = [file['current_version']['upload']['size'] for file in self._get_files()]
         return sum(sizes)
@@ -234,6 +237,9 @@ class DDSProjectSummary(DDSProject):
 
     def folder_count(self):
         return len(self._get_folders())
+
+    def root_folder_count(self):
+        return len(self.get_root_folders())
 
 
 class DDSProjectPermissions(DDSBase):

--- a/switchboard/dds_util.py
+++ b/switchboard/dds_util.py
@@ -225,7 +225,7 @@ class DDSProjectSummary(DDSProject):
     def _get_folders(self):
         return self._get_children_of_kind('dds-folder')
 
-    def get_root_folders(self):
+    def _get_root_folders(self):
         return [folder for folder in self._get_folders() if folder['parent']['kind'] == 'dds-project']
 
     def total_size(self):
@@ -239,7 +239,7 @@ class DDSProjectSummary(DDSProject):
         return len(self._get_folders())
 
     def root_folder_count(self):
-        return len(self.get_root_folders())
+        return len(self._get_root_folders())
 
 
 class DDSProjectPermissions(DDSBase):

--- a/switchboard/tests_ddsutil.py
+++ b/switchboard/tests_ddsutil.py
@@ -488,11 +488,11 @@ class DDSProjectSummaryTestCase(TestCase):
     def setUp(self):
         self.project = {'id': '123'}
         self.children = [
-            {'id': 'fo1', 'kind': 'dds-folder'},
+            {'id': 'fo1', 'kind': 'dds-folder', 'parent': {'kind': 'dds-project'}},
             {'id': 'fi1', 'kind': 'dds-file', 'current_version': {'upload': {'size': 100}}},
             {'id': 'fi2', 'kind': 'dds-file', 'current_version': {'upload': {'size': 200}}},
             {'id': 'fi3', 'kind': 'dds-file', 'current_version': {'upload': {'size': 300}}},
-            {'id': 'fo2', 'kind': 'dds-folder'}
+            {'id': 'fo2', 'kind': 'dds-folder', 'parent': {'kind': 'dds-folder'}}
         ]
 
     def test_constructor(self, mock_get_project_url):
@@ -519,6 +519,10 @@ class DDSProjectSummaryTestCase(TestCase):
     def test_folder_count(self, mock_get_project_url):
         project_summary = DDSProjectSummary({'id': '123', 'children': self.children})
         self.assertEqual(project_summary.folder_count(), 2)
+
+    def test_root_folder_count(self, mock_get_project_url):
+        project_summary = DDSProjectSummary({'id': '123', 'children': self.children})
+        self.assertEqual(project_summary.root_folder_count(), 1)
 
 
 class DDSProjectPermissionsTestCase(TestCase):


### PR DESCRIPTION
Adds a `root_folder_count` field to DDSProjectSummary to with the number of top-level folders

Required by https://github.com/Duke-GCB/datadelivery-ui/issues/48