### PR TITLE
use python:3.6.8 docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.6
+FROM python:3.6.8
 MAINTAINER dan.leehr@duke.edu
 
 # Set timezone


### PR DESCRIPTION
Changes base python docker image to fix issue #218 where s3 backed files were not able to be downloaded. The current python docker image (3.6.9) has `dh key too small`
errors when trying to download files from the S3 backend.
Fixes #218 