### PR TITLE
Show error for unauthorized user

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,6 +7,7 @@ jobs:
         environment:
           POSTGRES_USER: postgres
           POSTGRES_DB: d4s2
+          POSTGRES_HOST_AUTH_METHOD=trust
     steps:
       - checkout
       - restore_cache:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ jobs:
         environment:
           POSTGRES_USER: postgres
           POSTGRES_DB: d4s2
-          POSTGRES_HOST_AUTH_METHOD=trust
+          POSTGRES_HOST_AUTH_METHOD: trust
     steps:
       - checkout
       - restore_cache:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,6 +21,9 @@ jobs:
           paths:
             - "venv"
       - run:
+          name: Wait for db
+          command: dockerize -wait tcp://localhost:5432 -timeout 1m
+      - run:
           command: |
             source venv/bin/activate
             DJANGO_SETTINGS_MODULE=d4s2.settings_test python manage.py test

--- a/d4s2/settings_base.py
+++ b/d4s2/settings_base.py
@@ -134,7 +134,7 @@ EMAIL_BACKEND = 'django.core.mail.backends.console.EmailBackend'
 EMAIL_FROM_ADDRESS = 'noreply@localhost'
 
 REST_FRAMEWORK = {
-    'DEFAULT_FILTER_BACKENDS': ('rest_framework.filters.DjangoFilterBackend',),
+    'DEFAULT_FILTER_BACKENDS': ('django_filters.rest_framework.DjangoFilterBackend',),
     'DEFAULT_AUTHENTICATION_CLASSES': (
         'gcb_web_auth.dukeds_auth.DukeDSTokenAuthentication', # Allows users to authenticate with a DukeDS token
         'rest_framework_jwt.authentication.JSONWebTokenAuthentication', # Allows users to authenticate with a JWT

--- a/ownership/views.py
+++ b/ownership/views.py
@@ -8,7 +8,7 @@ except ImportError:
     from urllib import urlencode
 from d4s2_api.models import State
 from switchboard.s3_util import S3Exception, S3DeliveryType, S3NotRecipientException
-from switchboard.dds_util import DDSDeliveryType
+from switchboard.dds_util import DDSDeliveryType, DDSNotRecipientException
 from d4s2_api.utils import MessageDirection
 
 MISSING_TRANSFER_ID_MSG = 'Missing transfer ID.'
@@ -62,7 +62,7 @@ class DeliveryViewBase(TemplateView):
                 context.update(details.get_context())
                 context['delivery_type'] = self.delivery_type.name
             return context
-        except S3NotRecipientException:
+        except (S3NotRecipientException, DDSNotRecipientException):
             self.set_error_details(403, NOT_RECIPIENT_MSG)
 
     def _get_request_var(self, key):

--- a/switchboard/dds_util.py
+++ b/switchboard/dds_util.py
@@ -63,7 +63,12 @@ class DDSUtil(object):
         self.remote_store.revoke_user_project_permission(project, user)
 
     def get_project_transfer(self, transfer_id):
-        return self.remote_store.data_service.get_project_transfer(transfer_id)
+        try:
+            return self.remote_store.data_service.get_project_transfer(transfer_id)
+        except DataServiceError as e:
+            if e.status_code == 403:
+                raise DDSNotRecipientException()
+            raise
 
     def get_project_transfers(self):
         return self.remote_store.data_service.get_all_project_transfers()
@@ -598,3 +603,7 @@ class DDSAffiliate(DDSBase):
         """
         response = dds_util.get_auth_provider_affiliate(auth_provider_id, uid)
         return DDSAffiliate(response)
+
+
+class DDSNotRecipientException(Exception):
+    pass


### PR DESCRIPTION
Fixes #223 
- Displays an error message when the user doesn't have permission to accept a delivery. This can occur when a delivery recipient shares the acceptance URL with someone else.
- Fixes some recent problems in circleci testing related to the `POSTGRES_HOST_AUTH_METHOD` flag.
- Updates DjangoFilterBackend package name for DRF upgrade