### PR TITLE
better handle SMTP errors

### DIFF
--- a/d4s2/settings_docker.py
+++ b/d4s2/settings_docker.py
@@ -34,6 +34,7 @@ if os.getenv('D4S2_SMTP_HOST') is not None:
   EMAIL_BACKEND = 'django.core.mail.backends.smtp.EmailBackend'
   EMAIL_HOST = os.getenv('D4S2_SMTP_HOST')
   EMAIL_FROM_ADDRESS = os.getenv('D4S2_EMAIL_FROM_ADDRESS')
+  EMAIL_TIMEOUT = os.getenv('D4S2_EMAIL_TIMEOUT', 5)  # default to allowing 5 seconds when sending an email
 
 # Additional production security settings
 if os.getenv('D4S2_PRODUCTION'):

--- a/download_service/views.py
+++ b/download_service/views.py
@@ -15,6 +15,6 @@ def dds_project_zip(request, project_id, filename):
         response['Content-Disposition'] = 'attachment; filename={}'.format(filename)
         return response
     except NotFoundException as e:
-        raise Http404(e.message)
+        raise Http404(str(e))
     except NotSupportedException as e:
-        return HttpResponseServerError(content=e.message)
+        return HttpResponseServerError(content=str(e))

--- a/integration_tests/test_integration.py
+++ b/integration_tests/test_integration.py
@@ -143,9 +143,9 @@ class DeliveryIntegrationTestCase(APITestCase, ResponseStatusCodeTestCase):
         self.assertEqual(mock_message.mock_calls, [
             call(self.recipient_email, self.sender_email, 'Sender Delivery Accepted Subject',
                  'Sender Delivery Accepted Body', ANY, None),
-            call().send(),
             call(self.sender_email, self.recipient_email, 'Sender Delivery Accepted To Recipient Subject',
                  'Sender Delivery Accepted To Recipient Body', ANY, None),
+            call().send(),
             call().send()
         ])
 
@@ -322,8 +322,8 @@ class DeliveryIntegrationTestCase(APITestCase, ResponseStatusCodeTestCase):
         self.assertEqual(mock_message.mock_calls, [
             call(self.recipient_email, self.sender_email, 'Sender Delivery Accepted Subject',
                  'Sender Delivery Accepted Body', ANY, self.cc_email),
-            call().send(),
             call(self.sender_email, self.recipient_email, 'Sender Delivery Accepted To Recipient Subject',
                  'Sender Delivery Accepted To Recipient Body', ANY, self.cc_email),
+            call().send(),
             call().send()
         ])

--- a/ownership/test_views.py
+++ b/ownership/test_views.py
@@ -316,8 +316,8 @@ class ProcessTestCase(AuthenticatedTestCase):
         # check that the sender template subject/body was used to render the email
         self.assertEqual(mock_message.mock_calls, [
             call(ANY, ANY, sender_template1.subject, sender_template1.body, ANY, None),
-            call().send(),
             call(ANY, ANY, sender_template2.subject, sender_template2.body, ANY, None),
+            call().send(),
             call().send(),
         ])
 

--- a/ownership/views.py
+++ b/ownership/views.py
@@ -168,9 +168,9 @@ class ProcessView(DeliveryViewBase):
         try:
             self.warning_message = self.delivery_type.transfer_delivery(delivery, request.user)
         except S3Exception as e:
-            self.set_error_details(500, 'Unable to transfer s3 ownership: {}'.format(e.message))
+            self.set_error_details(500, 'Unable to transfer s3 ownership: {}'.format(str(e)))
         except DataServiceError as e:
-            self.set_error_details(500, 'Unable to transfer ownership: {}'.format(e.message))
+            self.set_error_details(500, 'Unable to transfer ownership: {}'.format(str(e)))
         except Exception as e:
             self.set_error_details(500, str(e))
 

--- a/switchboard/dds_util.py
+++ b/switchboard/dds_util.py
@@ -1,4 +1,5 @@
 from django.conf import settings
+import socket
 from ddsc.core.remotestore import RemoteStore
 from d4s2_api.models import EmailTemplate, DDSDelivery, ShareRole, Share, UserEmailTemplateSet
 from gcb_web_auth.backends.dukeds import make_auth_config
@@ -528,8 +529,14 @@ class DDSDeliveryType:
                                                                    MessageDirection.ToRecipient)
         # Save email messages first so the the emails can be resent if they fail
         delivery.mark_accepted(user.get_username(), sender_message.email_text, recipient_message.email_text)
-        sender_message.send()
-        recipient_message.send()
+        try:
+            sender_message.send()
+        except OSError as e:
+            warning_message += 'Failed to email to {}: {}\n'.format(sender_message.to, str(e))
+        try:
+            recipient_message.send()
+        except OSError as e:
+            warning_message += 'Failed to email to {}: {}\n'.format(recipient_message.to, str(e))
         return warning_message
 
     @staticmethod

--- a/switchboard/dds_util.py
+++ b/switchboard/dds_util.py
@@ -524,11 +524,12 @@ class DDSDeliveryType:
         sender_message = message_factory.make_processed_message('accepted',
                                                                 MessageDirection.ToSender,
                                                                 warning_message=warning_message)
-        sender_message.send()
         recipient_message = message_factory.make_processed_message('accepted_recipient',
                                                                    MessageDirection.ToRecipient)
-        recipient_message.send()
+        # Save email messages first so the the emails can be resent if they fail
         delivery.mark_accepted(user.get_username(), sender_message.email_text, recipient_message.email_text)
+        sender_message.send()
+        recipient_message.send()
         return warning_message
 
     @staticmethod

--- a/switchboard/dds_util.py
+++ b/switchboard/dds_util.py
@@ -365,7 +365,7 @@ class DeliveryDetails(object):
             base_context = self.get_context()
             user_message = self.get_user_message()
         except ValueError as e:
-            raise RuntimeError('Unable to retrieve information from DukeDS: {}'.format(e.message))
+            raise RuntimeError('Unable to retrieve information from DukeDS: {}'.format(str(e)))
 
         return {
             'service_name': base_context['service_name'],
@@ -495,7 +495,7 @@ class DeliveryUtil(object):
         try:
             self.dds_util.decline_project_transfer(self.delivery.transfer_id, reason)
         except ValueError as e:
-            raise RuntimeError('Unable to retrieve information from DukeDS: {}'.format(e.message))
+            raise RuntimeError('Unable to retrieve information from DukeDS: {}'.format(str(e)))
 
 
 class DDSDeliveryType:


### PR DESCRIPTION
- Save status and email text before sending emails. This will record data that can be used to  resending emails in the event of SMTP errors.
- Adds configurable email timeout setting. This will let the endpoints respond even if the connection to the SMTP server hangs.
- Fixes exception handling to be python3 compatible
