### PR TITLE
Use sender users's reply-to settings

### DIFF
--- a/d4s2_api/utils.py
+++ b/d4s2_api/utils.py
@@ -1,5 +1,5 @@
 from switchboard.mailer import generate_message
-
+from d4s2_api.models import UserEmailTemplateSet
 
 class MessageDirection(object):
     ToRecipient = 0
@@ -47,9 +47,10 @@ class Message(object):
 
 class MessageFactory(object):
 
-    def __init__(self, delivery_details):
+    def __init__(self, delivery_details, user):
         self.delivery_details = delivery_details
         self.email_template_set = delivery_details.email_template_set
+        self.user = user
 
     def make_share_message(self):
         # This method is only applicable if the internal delivery is a share type
@@ -73,10 +74,11 @@ class MessageFactory(object):
         return self._make_message(email_template)
 
     def get_reply_to_address(self, sender):
-        if self.email_template_set.reply_address:
-            return self.email_template_set.reply_address
-        else:
-            return sender.email
+        if UserEmailTemplateSet.user_is_setup(self.user):
+            reply_address = UserEmailTemplateSet.objects.get(user=self.user).email_template_set.reply_address
+            if reply_address:
+                return reply_address
+        return sender.email
 
     def get_cc_address(self):
         if self.email_template_set.cc_address:

--- a/switchboard/dds_util.py
+++ b/switchboard/dds_util.py
@@ -556,7 +556,8 @@ class DDSDeliveryType:
 class DDSMessageFactory(MessageFactory):
     def __init__(self, delivery, user):
         super(DDSMessageFactory, self).__init__(
-            DeliveryDetails(delivery, user)
+            DeliveryDetails(delivery, user),
+            user
         )
 
 

--- a/switchboard/s3_util.py
+++ b/switchboard/s3_util.py
@@ -348,7 +348,8 @@ class S3DeliveryType:
 class S3MessageFactory(MessageFactory):
     def __init__(self, s3_delivery, user):
         super(S3MessageFactory, self).__init__(
-            S3DeliveryDetails(s3_delivery, user)
+            S3DeliveryDetails(s3_delivery, user),
+            user
         )
 
 


### PR DESCRIPTION
Changes the reply-to email address to use the current user's setting. Before this change when sharing an accepted delivery the sender's reply-to email address would be used (if setup).

Fixes #230