### PR TITLE
Derive emails from username when not present

### DIFF
--- a/d4s2/settings_base.py
+++ b/d4s2/settings_base.py
@@ -183,3 +183,5 @@ JWT_AUTH = {
     'JWT_ALLOW_REFRESH': True,
     'JWT_EXPIRATION_DELTA': datetime.timedelta(seconds=7200),
 }
+
+USERNAME_EMAIL_HOST = os.getenv('D4S2_USERNAME_EMAIL_HOST')

--- a/switchboard/dds_util.py
+++ b/switchboard/dds_util.py
@@ -15,6 +15,14 @@ PROJECT_ADMIN_ID = 'project_admin'
 DDS_PERMISSIONS_ID_SEP = '_'
 
 
+def create_email_from_username(username):
+    # email addresses can be created by adding a host to a username for users who
+    # have their email addresses hidden in the DukeDS affiliates API
+    if settings.USERNAME_EMAIL_HOST:
+        return '{}@{}'.format(username, settings.USERNAME_EMAIL_HOST)
+    return None
+
+
 class DDSUtil(object):
     def __init__(self, user):
         if not user:
@@ -157,6 +165,8 @@ class DDSUser(DDSBase):
         self.first_name = user_dict.get('first_name')
         self.last_name = user_dict.get('last_name')
         self.email = user_dict.get('email')
+        if not self.email:
+            self.email = create_email_from_username(self.username)
 
     @staticmethod
     def fetch_list(dds_util, full_name_contains, email, username):
@@ -598,6 +608,8 @@ class DDSAffiliate(DDSBase):
         self.first_name = project_dict.get('first_name')
         self.last_name = project_dict.get('last_name')
         self.email = project_dict.get('email')
+        if not self.email:
+            self.email = create_email_from_username(self.uid)
 
     @staticmethod
     def fetch_list(dds_util, auth_provider_id, full_name_contains, email, username):


### PR DESCRIPTION
Some users do not have email addresses listed in DukeDS affiliates and users endpoints. For those users an email address can be created based on the username. Changes here create an email address from username when the email address field is empty and the D4S2_USERNAME_EMAIL_HOST env variable is set.

This should fix https://github.com/Duke-GCB/datadelivery-ui/issues/64