### PR TITLE
Upgrade gcb-web-auth to 1.1.2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -16,7 +16,7 @@ DukeDSClient==2.1.4
 enum34==1.1.6
 funcsigs==0.4
 future==0.16.0
-gcb-web-auth==1.1.1
+gcb-web-auth==1.1.2
 gevent==1.4.0
 greenlet==0.4.15
 gunicorn==19.7.1


### PR DESCRIPTION
This is to fix run.sh failing to run createddsendpoint.
Fixes #234 
