### PR TITLE
Add strsplit email template filters

### DIFF
--- a/switchboard/mailer.py
+++ b/switchboard/mailer.py
@@ -3,13 +3,24 @@ from django.template import Template, Context
 from django.utils.safestring import mark_safe
 from django.conf import settings
 
+LOAD_EMAIL_FILTERS = '{% load emailfilters %}'
+
+
+def template_with_email_filters(template_string):
+    """
+    Create a template that will load our email filters
+    :param template_string: str
+    :return: Template
+    """
+    return Template('{}{}'.format(LOAD_EMAIL_FILTERS, template_string))
+
 
 def generate_message(reply_to_email, rcpt_email, cc_email, template_subject, template_body, context):
     # Mark the fields in context as safe, since we're not outputting HTML
     for k in context:
         context[k] = mark_safe(context[k])
-    subject = Template(template_subject).render(Context(context))
-    body = Template(template_body).render(Context(context))
+    subject = template_with_email_filters(template_subject).render(Context(context))
+    body = template_with_email_filters(template_body).render(Context(context))
     from_email = settings.EMAIL_FROM_ADDRESS
     cc_email_list = [cc_email] if cc_email else []
     return EmailMessage(subject, body, from_email, [rcpt_email], cc=cc_email_list, reply_to=[reply_to_email])

--- a/switchboard/templatetags/emailfilters.py
+++ b/switchboard/templatetags/emailfilters.py
@@ -1,0 +1,16 @@
+from django import template
+from django.template.defaultfilters import stringfilter
+
+register = template.Library()
+
+@register.filter
+@stringfilter
+def strsplit(value, sep=None):
+    return value.split(sep)
+
+@register.filter
+def listidx(value, idx=0):
+    try:
+        return value[idx]
+    except IndexError:
+        return ''

--- a/switchboard/tests_mailer.py
+++ b/switchboard/tests_mailer.py
@@ -42,3 +42,22 @@ class MailerTestCase(TestCase):
         }
         message = generate_message(self.reply_to_email, self.rcpt_email, self.cc_email, self.subject, template_text, context)
         self.assertIn("message I don't want this", message.body)
+
+    def test_generate_message_strsplit(self):
+        template_text = 'message {{ message | strsplit:"_" | listidx:1 }}'
+        context = {
+            'message': "This_that_other",
+        }
+        message = generate_message(self.reply_to_email, self.rcpt_email, self.cc_email, self.subject, template_text, context)
+        self.assertEqual("message that", message.body)
+
+        context = {
+            'message': "one_two_three_four",
+        }
+        message = generate_message(self.reply_to_email, self.rcpt_email, self.cc_email, self.subject, template_text, context)
+        self.assertEqual("message two", message.body)
+        context = {
+            'message': "one",
+        }
+        message = generate_message(self.reply_to_email, self.rcpt_email, self.cc_email, self.subject, template_text, context)
+        self.assertEqual("message ", message.body)


### PR DESCRIPTION
Adds strsplit and listidx template filters to allow extracting parts of a project name in an email template.
Fixes #237