### PR TITLE
Add accepted/canceled date to API

### DIFF
--- a/d4s2_api_v2/serializers.py
+++ b/d4s2_api_v2/serializers.py
@@ -54,6 +54,8 @@ class DDSProjectTransferSerializer(serializers.Serializer):
     from_user = DDSUserSerializer()
     project = DDSProjectSerializer()
     delivery = serializers.UUIDField()
+    created_on = serializers.DateTimeField()
+    last_updated_on = serializers.DateTimeField()
 
     class Meta:
         resource_name = 'duke-ds-project-transfers'

--- a/d4s2_api_v2/tests_api.py
+++ b/d4s2_api_v2/tests_api.py
@@ -445,6 +445,10 @@ class DDSProjectTransfersViewSetTestCase(AuthenticatedResourceTestCase):
                     'id': 'transfer1',
                     'status': 'pending',
                     'status_comment': 'Some status comment',
+                    'audit': {
+                        'created_on': '2019-01-01',
+                        'last_updated_on': None
+                    },
                     'to_users': [
                         {
                             'id': 'user1',
@@ -465,6 +469,10 @@ class DDSProjectTransfersViewSetTestCase(AuthenticatedResourceTestCase):
                     'id': 'transfer2',
                     'status': 'accepted',
                     'status_comment': None,
+                    'audit': {
+                        'created_on': '2019-01-01',
+                        'last_updated_on': '2019-06-01'
+                    },
                     'to_users': [
                         {
                             'id': 'user1',
@@ -518,6 +526,10 @@ class DDSProjectTransfersViewSetTestCase(AuthenticatedResourceTestCase):
             'id': 'transfer1',
             'status': 'pending',
             'status_comment': 'Some status comment',
+            'audit': {
+                'created_on': '2019-01-01',
+                'last_updated_on': '2019-06-01'
+            },
             'to_users': [
                 {
                     'id': 'user1',

--- a/d4s2_api_v2/tests_api.py
+++ b/d4s2_api_v2/tests_api.py
@@ -502,6 +502,9 @@ class DDSProjectTransfersViewSetTestCase(AuthenticatedResourceTestCase):
         self.assertEqual(transfer['id'], 'transfer1')
         self.assertEqual(transfer['status'], 'pending')
         self.assertEqual(transfer['status_comment'], 'Some status comment')
+        self.assertEqual(transfer['created_on'], '2019-01-01')
+        self.assertEqual(transfer['last_updated_on'], None)
+
         self.assertEqual(len(transfer['to_users']), 1)
         self.assertEqual(transfer['to_users'][0]['id'], 'user1')
         self.assertEqual(transfer['from_user']['id'], 'user2')
@@ -517,6 +520,8 @@ class DDSProjectTransfersViewSetTestCase(AuthenticatedResourceTestCase):
         self.assertEqual(transfer['from_user']['id'], 'user3')
         self.assertEqual(transfer['project']['name'], 'Rat')
         self.assertEqual(transfer['delivery'], None)
+        self.assertEqual(transfer['created_on'], '2019-01-01')
+        self.assertEqual(transfer['last_updated_on'], '2019-06-01')
 
     @patch('d4s2_api_v2.api.DDSUtil')
     @patch('d4s2_api_v2.api.DDSUtil.get_project_url')
@@ -561,6 +566,8 @@ class DDSProjectTransfersViewSetTestCase(AuthenticatedResourceTestCase):
         self.assertEqual(transfer['to_users'][0]['id'], 'user1')
         self.assertEqual(transfer['from_user']['id'], 'user2')
         self.assertEqual(transfer['project']['name'], 'Mouse')
+        self.assertEqual(transfer['created_on'], '2019-01-01')
+        self.assertEqual(transfer['last_updated_on'], '2019-06-01')
 
 
 class UserLogin(object):

--- a/switchboard/dds_util.py
+++ b/switchboard/dds_util.py
@@ -308,6 +308,9 @@ class DDSProjectTransfer(DDSBase):
             if delivery_obj.project_name:
                 self.project_dict['name'] = delivery_obj.project_name
         self.project = DDSProject(self.project_dict)
+        audit = transfer_dict['audit']
+        self.created_on = audit['created_on']
+        self.last_updated_on = audit['last_updated_on']
 
     @staticmethod
     def _lookup_delivery(transfer_id):

--- a/switchboard/tests_ddsutil.py
+++ b/switchboard/tests_ddsutil.py
@@ -876,6 +876,8 @@ class DDSProjectTransferTestCase(TestCase):
     def test_constructor(self, mock_dds_util):
         transfer = DDSProjectTransfer(transfer_dict=self.transfer_dict)
         self.assertEqual(transfer.project.name, 'MouseRNA')
+        self.assertEqual(transfer.created_on, '2019-01-01')
+        self.assertEqual(transfer.last_updated_on, None)
 
     @patch('switchboard.dds_util.DDSUtil')
     def test_constructor_with_name_override(self, mock_dds_util):

--- a/switchboard/tests_ddsutil.py
+++ b/switchboard/tests_ddsutil.py
@@ -860,6 +860,10 @@ class DDSProjectTransferTestCase(TestCase):
             'id': '123',
             'from_user': {},
             'to_users': [],
+            'audit': {
+                'created_on': '2019-01-01',
+                'last_updated_on': None
+            },
             'project': {
                 'name': 'MouseRNA'
             }


### PR DESCRIPTION
Changes to support fixing https://github.com/Duke-GCB/datadelivery-ui/issues/70
Also included the "createdOn" date.
This just forwards data already stored in DukeDS.