### PR TITLE
Allow zip downloads to start faster

### DIFF
--- a/download_service/tests_zipbuilder.py
+++ b/download_service/tests_zipbuilder.py
@@ -3,7 +3,7 @@ from download_service.zipbuilder import DDSZipBuilder, NotFoundException, NotSup
 from ddsc.sdk.client import Client, File, FileDownload, Project, DDSConnection
 from ddsc.core.ddsapi import DataServiceError
 from requests import Response
-from unittest.mock import Mock, patch, create_autospec, PropertyMock, call
+from unittest.mock import Mock, patch, create_autospec, PropertyMock, call, ANY
 from collections import OrderedDict
 
 
@@ -19,7 +19,12 @@ class DDSZipBuilderTestCase(TestCase):
     def setUp(self):
         self.mock_client = create_autospec(Client)
         self.mock_client.dds_connection = create_autospec(DDSConnection)
+        self.mock_client.dds_connection.config = Mock(page_size=100)
         self.project_id = '514d0f77-a167-400d-8466-3043428029fe'
+        self.project_file1 = Mock(size=100, path='file1.txt', file_url={'host':'somehost', 'url':'/file1.txt'})
+        self.project_file1.id = '123'
+        self.project_file2 = Mock(size=200, path='file2.txt', file_url={'host':'somehost', 'url':'/file2.txt'})
+        self.project_file2.id = '456'
 
     def test_init(self):
         builder = DDSZipBuilder(self.project_id, self.mock_client)
@@ -39,27 +44,22 @@ class DDSZipBuilderTestCase(TestCase):
         self.assertEqual(builder.get_filename(), 'project-xyz.zip')
 
     @patch('download_service.zipbuilder.PathToFiles')
-    def test_get_dds_paths(self, mock_path_to_files):
+    def test_get_project_file_generator(self, mock_path_to_files):
         mock_project = DDSZipBuilderTestCase.mock_project_with_name('project-xyz')
         self.mock_client.get_project_by_id.return_value = mock_project
         builder = DDSZipBuilder(self.project_id, self.mock_client)
-        dds_paths = builder.get_dds_paths()
-        # get_project_by_id should be called with the project id
-        self.assertEqual(self.mock_client.get_project_by_id.call_args, call(self.project_id))
-        # PathToFiles().add_paths_for_children_of_node should be called with the project
-        self.assertEqual(mock_path_to_files.return_value.add_paths_for_children_of_node.call_args, call(mock_project))
-        self.assertEqual(dds_paths, mock_path_to_files.return_value.paths)
+        result = builder.get_project_file_generator()
+        self.assertEqual(result, mock_project.get_project_files_generator.return_value)
+        mock_project.get_project_files_generator.assert_called_with(page_size=100)
 
     def test_get_url(self):
         mock_file_download = create_autospec(FileDownload, host='http://example.org', url='/path/file.ext', http_verb='GET')
         mock_get_file_download = self.mock_client.dds_connection.get_file_download
         mock_get_file_download.return_value = mock_file_download
         builder = DDSZipBuilder(self.project_id, self.mock_client)
-        mock_file = create_autospec(File)
-        mock_file.id = 'file-id'
-        url = builder.get_url(mock_file)
+        url = builder.get_url(file_id='1234')
         # Get file download should have been called with the file id
-        self.assertEqual(mock_get_file_download.call_args, call('file-id'))
+        self.assertEqual(mock_get_file_download.call_args, call('1234'))
         # Built URL should be assembled from the properties of the mock_file_download
         self.assertEqual(url, 'http://example.org/path/file.ext')
 
@@ -69,112 +69,166 @@ class DDSZipBuilderTestCase(TestCase):
         mock_chunks = ['chunk1','chunk2','chunk3']
         url = 'https://example.org/path/file.ext'
         mock_response = create_autospec(Response)
+        mock_response.status_code = 403
         mock_requests_get.return_value = mock_response
         mock_response.raw = Mock(stream=Mock(return_value=mock_chunks))
         mock_get_url.return_value = url
         builder = DDSZipBuilder(self.project_id, self.mock_client)
-        mock_file = create_autospec(File)
-        fetched = builder.fetch(mock_file)
+        mock_project_file = Mock(
+            file_url={'host':'somehost', 'url': '/file1.txt'},
+        )
+        mock_project_file.id = '123'
+        fetched = builder.fetch(mock_project_file)
         self.assertEqual(list(fetched), mock_chunks)
-        # get_url should be called with the file
-        self.assertEqual(mock_get_url.call_args, call(mock_file))
-        # requests_get should be called with the url and stream=True
-        self.assertEqual(mock_requests_get.call_args, call(url, stream=True))
 
-    @patch('download_service.zipbuilder.requests.get')
-    @patch('download_service.zipbuilder.DDSZipBuilder.get_url')
-    def test_fetch_does_not_get_file_url_until_iterated(self, mock_get_url, mock_requests_get):
-        builder = DDSZipBuilder(self.project_id, self.mock_client)
-        # Instantiating a DDSZipBuilder will not fetch any URLs yet
-        self.assertFalse(mock_get_url.called)
-        fetched = builder.fetch(create_autospec(File))
-        # Invoking DDSZipBuilder.fetch() to get a generator must not call get_url
-        self.assertFalse(mock_get_url.called)
-        # Iterating on the generator will trigger the call
-        for _ in fetched:
-            pass
-        self.assertTrue(mock_get_url.called)
-        # Also requests.get should have been called
-        self.assertTrue(mock_requests_get.called)
+        # try "expired" url then try url returned from get_url
+        mock_requests_get.assert_has_calls([
+            call('somehost/file1.txt', stream=True),
+            call('https://example.org/path/file.ext', stream=True),
+        ])
+
+        # get_url should be called with the file
+        mock_get_url.assert_called_with('123')
 
     @patch('download_service.zipbuilder.ZipFile')
-    @patch('download_service.zipbuilder.DDSZipBuilder.get_dds_paths')
+    @patch('download_service.zipbuilder.DDSZipBuilder.get_project_file_generator')
     @patch('download_service.zipbuilder.DDSZipBuilder.fetch')
-    def test_build_streaming_zipfile(self, mock_fetch, mock_get_dds_paths, mock_zipfile):
-        mock_dds_files = OrderedDict({
-            'file1.txt': create_autospec(File, current_version={'upload': {'size': 100}}),
-            'file2.txt': create_autospec(File, current_version={'upload': {'size': 200}})
-        })
-        mock_get_dds_paths.return_value = mock_dds_files
+    def test_build_streaming_zipfile(self, mock_fetch, mock_get_project_file_generator, mock_zipfile):
+        mock_get_project_file_generator.return_value = iter(
+            [
+                (self.project_file1, None),
+                (self.project_file2, None),
+            ]
+        )
         builder = DDSZipBuilder(self.project_id, self.mock_client)
-        streaming_zipfile = builder.build_streaming_zipfile()
-        # it should call mock_get_dds_paths
-        self.assertTrue(mock_get_dds_paths.called)
-        # It should init a zipfile with allowZip64=true
-        self.assertEqual(mock_zipfile.call_args, call(allowZip64=True))
-        # it should call write_iter with filename, fetch results, and buffer size
-        self.assertEqual(mock_zipfile.return_value.write_iter.mock_calls, [
+        response = builder.build_streaming_zipfile()
+
+        # check generator responses
+        self.assertEqual(next(response), mock_zipfile.return_value.flush.return_value)
+        self.assertEqual(next(response), mock_zipfile.return_value.flush.return_value)
+        self.assertEqual(next(response), mock_zipfile.return_value)
+        with self.assertRaises(StopIteration):
+            next(response)
+
+        # check zipfile added with appropriate files
+        mock_zipfile.return_value.write_iter.assert_has_calls([
             call('file1.txt', mock_fetch.return_value, buffer_size=100),
             call('file2.txt', mock_fetch.return_value, buffer_size=200),
         ])
-        # It should call fetch for each dds file, in order
-        self.assertEqual(mock_fetch.mock_calls, [
-            call(mock_dds_files['file1.txt']),
-            call(mock_dds_files['file2.txt'])
-        ])
-        # it should return the zip file
-        self.assertEqual(streaming_zipfile, mock_zipfile.return_value)
 
     @patch('download_service.zipbuilder.requests.get')
     @patch('download_service.zipbuilder.DDSZipBuilder.get_url')
-    @patch('download_service.zipbuilder.DDSZipBuilder.get_dds_paths')
-    def test_call_order(self, mock_get_dds_paths, mock_get_url, mock_requests_get):
+    @patch('download_service.zipbuilder.DDSZipBuilder.get_project_file_generator')
+    @patch('download_service.zipbuilder.is_expired_dds_response')
+    def test_call_order(self, mock_is_expired_dds_response, mock_get_project_file_generator, mock_get_url,
+                        mock_requests_get):
         """
         Test the correct call order when streaming the zip file.
         Example uses a 2 file project
         """
+        mock_is_expired_dds_response.return_value = False
 
         manager = Mock()
         manager.attach_mock(mock_get_url, 'get_url')
         manager.attach_mock(mock_requests_get, 'requests_get')
         manager.attach_mock(mock_requests_get.return_value.raw.stream, 'response_stream')
-        manager.attach_mock(mock_get_dds_paths, 'get_dds_paths')
+        manager.attach_mock(mock_get_project_file_generator, 'get_project_file_generator')
 
-        mock_dds_files = OrderedDict({
-            'file1.txt': create_autospec(File, current_version={'upload': {'size': 100}}),
-            'file2.txt': create_autospec(File, current_version={'upload': {'size': 200}})
-        })
-        mock_get_dds_paths.return_value = mock_dds_files
+        mock_get_project_file_generator.return_value = iter(
+            [
+                (self.project_file1, None),
+                (self.project_file2, None),
+            ]
+        )
         mock_requests_get.return_value.raw.stream.return_value = []
 
         builder = DDSZipBuilder(self.project_id, self.mock_client)
         streaming_zipfile = builder.build_streaming_zipfile()
-        # Before iterating the only call that should be made is getting the paths
-        self.assertEqual(manager.mock_calls, [call.get_dds_paths(), ])
-        for _ in streaming_zipfile:
-            pass
+        # Iterate through the generator
+        for zipfile_data in streaming_zipfile:
+            list(zipfile_data)
 
         # After iterating, call order should be
         #
-        # 1. get_dds_paths - Get project paths
-        # 2. get_url - Get download URL for file 1
-        # 3. requests_get - Begin retrieval of data for file 1
+        # 1. get_project_file_generator - Get project files
+        # 2. requests_get - Begin retrieval of data for file 1
+        # 3. requests_get.raise_for_status - verify the response was good
         # 4. response_stream - Get response stream generator for file 1
-        # 2. get_url - Get download URL for file 2
-        # 3. requests_get - Begin retrieval of data for file 2
-        # 4. response_stream - Get response stream generator for file 2
+        # 5. requests_get - Begin retrieval of data for file 2
+        # 6. requests_get.raise_for_status - verify the response was good
+        # 7. response_stream - Get response stream generator for file 2
 
         expected_calls = [
-            call.get_dds_paths(),
-            call.get_url(mock_dds_files['file1.txt']),
-            call.requests_get(mock_get_url.return_value, stream=True),
+            call.get_project_file_generator(),
+            call.requests_get('somehost/file1.txt', stream=True),
+            call.requests_get().raise_for_status(),
             call.response_stream(),
-            call.get_url(mock_dds_files['file2.txt']),
-            call.requests_get(mock_get_url.return_value, stream=True),
-            call.response_stream(),
+            call.requests_get('somehost/file2.txt', stream=True),
+            call.requests_get().raise_for_status(),
+            call.response_stream()
         ]
-        self.assertEqual(manager.mock_calls, expected_calls)
+        manager.assert_has_calls(expected_calls)
 
+
+    @patch('download_service.zipbuilder.requests.get')
+    @patch('download_service.zipbuilder.DDSZipBuilder.get_url')
+    @patch('download_service.zipbuilder.DDSZipBuilder.get_project_file_generator')
+    @patch('download_service.zipbuilder.is_expired_dds_response')
+    def test_call_order_one_expired(self, mock_is_expired_dds_response, mock_get_project_file_generator, mock_get_url,
+                        mock_requests_get):
+        """
+        Test the correct call order when streaming the zip file where the first file has an expired URL
+        Example uses a 2 file project
+        """
+        mock_is_expired_dds_response.side_effect = [
+            True,
+            False
+        ]
+
+        manager = Mock()
+        manager.attach_mock(mock_get_url, 'get_url')
+        manager.attach_mock(mock_requests_get, 'requests_get')
+        manager.attach_mock(mock_requests_get.return_value.raw.stream, 'response_stream')
+        manager.attach_mock(mock_get_project_file_generator, 'get_project_file_generator')
+
+        mock_get_project_file_generator.return_value = iter(
+            [
+                (self.project_file1, None),
+                (self.project_file2, None),
+            ]
+        )
+        mock_requests_get.return_value.raw.stream.return_value = []
+
+        builder = DDSZipBuilder(self.project_id, self.mock_client)
+        streaming_zipfile = builder.build_streaming_zipfile()
+        # Iterate through the generator
+        for zipfile_data in streaming_zipfile:
+            list(zipfile_data)
+
+        # After iterating, call order should be
+        #
+        # 1. get_project_file_generator - Get project files
+        # 2. requests_get - Begin retrieval of data for file 1
+        # 3. get_url - Fetch url since URL was expired
+        # 4. requests_get - Begin retrieval of new URL for file 1
+        # 5. requests_get.raise_for_status - verify the response was good
+        # 6. response_stream - Get response stream generator for file 1
+        # 7. requests_get - Begin retrieval of data for file 2
+        # 8. requests_get.raise_for_status - verify the response was good
+        # 9. response_stream - Get response stream generator for file 2
+
+        expected_calls = [
+            call.get_project_file_generator(),
+            call.requests_get('somehost/file1.txt', stream=True),
+            call.get_url('123'),
+            call.requests_get(mock_get_url.return_value, stream=True),
+            call.requests_get().raise_for_status(),
+            call.response_stream(),
+            call.requests_get('somehost/file2.txt', stream=True),
+            call.requests_get().raise_for_status(),
+            call.response_stream()
+        ]
+        manager.assert_has_calls(expected_calls)
 
 class MockDataServiceError(DataServiceError):
 
@@ -187,6 +241,7 @@ class DDSZipBuilderExceptionsTestCase(TestCase):
     def setUp(self):
         self.mock_client = create_autospec(Client)
         self.mock_client.dds_connection = create_autospec(DDSConnection)
+        self.mock_client.dds_connection.config = Mock(page_size=100)
         self.project_id = 'abc'
         self.file_id = '123'
         self.mock_dds_file = create_autospec(File, id=self.file_id)
@@ -205,12 +260,12 @@ class DDSZipBuilderExceptionsTestCase(TestCase):
     def test_get_dds_paths_catches_dataservice_404_raises_not_found(self):
         self.mock_client.get_project_by_id.side_effect = MockDataServiceError(404)
         with self.assertRaisesMessage(NotFoundException, "Project abc not found"):
-            self.builder.get_dds_paths()
+            self.builder.get_project_file_generator()
 
     def test_get_dds_paths_raises_other_dataservice_errors(self):
         self.mock_client.get_project_by_id.side_effect = MockDataServiceError(500)
         with self.assertRaises(DataServiceError):
-            self.builder.get_dds_paths()
+            self.builder.get_project_file_generator()
 
     def test_get_url_checks_http_verb_raises_not_supported(self):
         self.mock_client.dds_connection.get_file_download.return_value = create_autospec(FileDownload, http_verb='POST')
@@ -220,7 +275,7 @@ class DDSZipBuilderExceptionsTestCase(TestCase):
     def test_get_url_catches_dataservice_404_raises_not_found(self):
         self.mock_client.dds_connection.get_file_download.side_effect = MockDataServiceError(404)
         with self.assertRaisesMessage(NotFoundException, "File with id 123 not found"):
-            self.builder.get_url(self.mock_dds_file)
+            self.builder.get_url(file_id='123')
 
     def test_get_url_raises_other_dataservice_errors(self):
         self.mock_client.dds_connection.get_file_download.side_effect = MockDataServiceError(500)

--- a/download_service/tests_zipbuilder.py
+++ b/download_service/tests_zipbuilder.py
@@ -101,14 +101,7 @@ class DDSZipBuilderTestCase(TestCase):
             ]
         )
         builder = DDSZipBuilder(self.project_id, self.mock_client)
-        response = builder.build_streaming_zipfile()
-
-        # check generator responses
-        self.assertEqual(next(response), mock_zipfile.return_value.flush.return_value)
-        self.assertEqual(next(response), mock_zipfile.return_value.flush.return_value)
-        self.assertEqual(next(response), mock_zipfile.return_value)
-        with self.assertRaises(StopIteration):
-            next(response)
+        list(builder.build_streaming_zipfile())
 
         # check zipfile added with appropriate files
         mock_zipfile.return_value.write_iter.assert_has_calls([

--- a/download_service/zipbuilder.py
+++ b/download_service/zipbuilder.py
@@ -1,7 +1,17 @@
 from zipstream import ZipFile
 from ddsc.sdk.client import PathToFiles
 from ddsc.core.ddsapi import DataServiceError
+from ddsc.core.download import SWIFT_EXPIRED_STATUS_CODE, S3_EXPIRED_STATUS_CODE
 import requests
+
+
+def is_expired_dds_response(response):
+    """
+    Check status_code of the response for the two values denoting expired URLs
+    :param response: requests.Response
+    :return: bool: True when the response is expired status
+    """
+    return response.status_code == SWIFT_EXPIRED_STATUS_CODE or response.status_code == S3_EXPIRED_STATUS_CODE
 
 
 class ZipBuilderException(BaseException):
@@ -29,6 +39,7 @@ class DDSZipBuilder(object):
         """
         self.project_id = project_id
         self.client = client
+        self.page_size = client.dds_connection.config.page_size
 
     @staticmethod
     def _handle_dataservice_error(e, message):
@@ -67,53 +78,47 @@ class DDSZipBuilder(object):
         if filename != expected_filename:
             raise NotFoundException('Project {} not found'.format(self.project_id))
 
-    def get_dds_paths(self):
+    def get_project_file_generator(self):
         """
-        Builds a mapping of file paths (strings) in the dds project to ddsc.sdk.client.File objects
-        :return: OrderedDict where keys are relative paths in the project and values are ddsc.sdk.client.File objects
+        Returns a generator that returns DukeDS files for the current project including a download url
+        :return: generator yielding ddsc.core.remotestore.ProjectFile, requests.Response.headers tuples
         """
         try:
             project = self.client.get_project_by_id(self.project_id)
-            ptf = PathToFiles()
-            ptf.add_paths_for_children_of_node(project)
-            return ptf.paths  # OrderedDict of path -> File
+            return project.get_project_files_generator(page_size=self.page_size)
         except DataServiceError as e:
             DDSZipBuilder._handle_dataservice_error(e, 'Project {} not found'.format(self.project_id))
 
-    def get_url(self, dds_file):
+    def get_url(self, file_id):
         """
-        Uses the client to get a download URL for a ddsc.sdk.client.File object. This URL will be signed with an
+        Generate a file download URL for a DDS file id. This URL will be signed with an
         expiration date, so this method should only be called right before the URL will be fetched.
-
-        :param dds_file: A ddsc.sdk.client.File object for which to get a URL
+        :param file_id: str: DDS file id
         :return: The URL string to GET.
         """
-        # This is a time-sensitive call, so we should only do it right before fetch
         try:
-            file_download = self.client.dds_connection.get_file_download(dds_file.id)
+            file_download = self.client.dds_connection.get_file_download(file_id)
             if file_download.http_verb == 'GET':
                 return '{}{}'.format(file_download.host, file_download.url)
             else:
                 raise NotSupportedException('This file requires an unsupported download method: {}'.format(file_download.http_verb))
         except DataServiceError as e:
-            DDSZipBuilder._handle_dataservice_error(e, 'File with id {} not found'.format(dds_file.id))
+            DDSZipBuilder._handle_dataservice_error(e, 'File with id {} not found'.format(file_id))
 
-    def fetch(self, dds_file):
+    def fetch(self, project_file):
         """
         Generator to provide the contents of the DDS file using requests.get with a streaming response.
-
-        Note: Since self.get_url() returns a URL that will expire, it's critical that the yield and the get_url()
-        call appear in the same function. The 'yield' in this function actually causes the get_url() call to be deferred
-        until the first time the generator is consumed. If the yield were in a nested function, get_url() would be
-        called immediately and the URL could easily expire before it's fetched.
-
-        :param dds_file: A ddsc.sdk.client.File object to fetch
+        :param project_file: ddsc.core.remotestore.ProjectFile containing file info and a potentially expired url
         :return: generator, bytes of the DDS file fetched from its URL.
         """
         # Due to the specifics of how python generators work, we have to make sure the yield appears in the same
-        # function as the call to self.get_url().
-        url = self.get_url(dds_file)
+        # function as the call to self.get_url()
+        url = project_file.file_url['host'] + project_file.file_url['url']
         response = requests.get(url, stream=True)
+        if is_expired_dds_response(response):
+            url = self.get_url(project_file.id)
+            response = requests.get(url, stream=True)
+        response.raise_for_status()
         for chunk in response.raw.stream():
             yield chunk
 
@@ -126,9 +131,8 @@ class DDSZipBuilder(object):
         # Set allowZip64 explicitly - it normally looks at file size but since we're building on the fly
         # we don't know that ahead of time
         zipfile = ZipFile(allowZip64=True)
-        paths = self.get_dds_paths()
-        for (filename, dds_file) in paths.items():
+        for project_file, _ in self.get_project_file_generator():
             # Must provide buffer_size so that write_iter will know to use zip64
-            file_size = dds_file.current_version['upload']['size']
-            zipfile.write_iter(filename, self.fetch(dds_file), buffer_size=file_size)
-        return zipfile
+            zipfile.write_iter(project_file.path, self.fetch(project_file), buffer_size=project_file.size)
+            yield from zipfile.flush()
+        yield from zipfile

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,11 +12,11 @@ django-simple-history==1.9.1
 django-sslserver==0.19
 djangorestframework==3.9.1
 drf-ember-backend==1.1
-DukeDSClient==2.1.4
+DukeDSClient==3.0.0
 enum34==1.1.6
 funcsigs==0.4
 future==0.16.0
-gcb-web-auth==1.1.2
+gcb-web-auth==1.1.3
 gevent==1.4.0
 greenlet==0.4.15
 gunicorn==19.7.1
@@ -41,4 +41,4 @@ six==1.10.0
 traitlets==4.3.1
 wcwidth==0.1.7
 whitenoise==3.3.1
-zipstream-new==1.1.5
+zipstream-new==1.1.8


### PR DESCRIPTION
Batches file requests and uses zip.flush() so larger projects will begin downloading quicker.
Uses batch size based on DukeDSClient config.
Upgrades DukeDSClient to use simplified generator for fetching DDS files.
Upgrades gcb-web-auth to be consistent with DukeDSClient version.
Upgrades zipstream-new to use `yield from zipfile.flush()` so the zip file starts downloading when the first file is processed.


Fixes part of #222