### PR TITLE
Upgrade gcb-web-auth to 1.1.4

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -16,7 +16,7 @@ DukeDSClient==3.1.0
 enum34==1.1.6
 funcsigs==0.4
 future==0.16.0
-gcb-web-auth==1.1.3
+gcb-web-auth==1.1.4
 gevent==1.4.0
 greenlet==0.4.15
 gunicorn==19.7.1


### PR DESCRIPTION
Upgrades gcb-web-auth so circleci tests will not fail to install requirements in PRs #244 and #243.