### PR TITLE
Disable TLS 1.0 and TLS 1.1

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -20,7 +20,7 @@ http {
 
     ssl on;
     ssl_session_cache  builtin:1000  shared:SSL:10m;
-    ssl_protocols  TLSv1 TLSv1.1 TLSv1.2;
+    ssl_protocols  TLSv1.2 TLSv1.3;
     ssl_ciphers HIGH:!aNULL:!eNULL:!EXPORT:!CAMELLIA:!DES:!MD5:!PSK:!RC4;
     ssl_prefer_server_ciphers on;
 


### PR DESCRIPTION
Updates nginx config to allow only TLSv1.2 and TLSv1.3.
Removes TLS 1.1 since it is now deprecated.