### PR TITLE
Upgrade ipython for vulnerability

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -20,7 +20,7 @@ gcb-web-auth==1.1.4
 gevent==1.4.0
 greenlet==0.4.15
 gunicorn==19.7.1
-ipython==5.1.0
+ipython==7.16.3
 ipython-genutils==0.1.0
 mock==1.3.0
 oauthlib==2.0.0
@@ -29,7 +29,6 @@ pathlib2==2.1.0
 pbr==1.8.1
 pexpect==4.2.1
 pickleshare==0.7.4
-prompt-toolkit==1.0.9
 psycopg2==2.7.3.2
 ptyprocess==0.5.1
 Pygments==2.7.4


### PR DESCRIPTION
https://ipython.readthedocs.io/en/stable/whatsnew/version8.html#ipython-8-0-1-cve-2022-21699